### PR TITLE
Move PR Validation to Github actions

### DIFF
--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -1,0 +1,47 @@
+name: PR Validation
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  Tests:
+    runs-on: ubuntu-latest
+    container:
+      image: dscdatascience.docker.repositories.sapcdn.io/pr_validation:2102a
+      credentials:
+          username: ${{ secrets.ARTIFACTORY_USR }}
+          password: ${{ secrets.ARTIFACTORY_PWD }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: prepare
+        run: |
+          pip install -r requirements.txt
+          pip install pytest
+
+      - name: pytest
+        run: pytest -q tests
+
+
+  Linting:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+
+      - uses: actions/checkout@v2
+
+      - name: prepare
+        run: | 
+          pip install -r .ci/requirements_pr.txt
+          git fetch --depth 1 origin main
+
+      - name: bandit
+        run: ./.ci/run_lint.sh bandit "--silent --ini setup.cfg"
+      - name: flake8
+        run: ./.ci/run_lint.sh flake8
+      - name: pydocstyle
+        run: ./.ci/run_lint.sh pydocstyle


### PR DESCRIPTION
PR validation with Github actions is available to the Github community whereas our Jenkins is not.

Additional feature remarks:
- Split into testing and linting for faster response on linting
- Testing uses our container because all packages need to be installed and
  downloading our docker image is supposed to be faster
- Linting uses the base ubuntu with setup-python action for a very lightweight
  and quick setup of a python container, which makes linting a very fast job