### PR TITLE
Various documentation fixes

### DIFF
--- a/docs/apidoc/sailor.assetcentral.model.rst
+++ b/docs/apidoc/sailor.assetcentral.model.rst
@@ -1,5 +1,5 @@
 :mod:`sailor.assetcentral.model`
-===========================================
+================================
 
 .. automodule:: sailor.assetcentral.model
    :members:

--- a/docs/apidoc/sailor.assetcentral.rst
+++ b/docs/apidoc/sailor.assetcentral.rst
@@ -9,10 +9,10 @@ Submodules
 
    sailor.assetcentral.constants
    sailor.assetcentral.equipment
-   sailor.assetcentral.model
    sailor.assetcentral.failure_mode
    sailor.assetcentral.indicators
    sailor.assetcentral.location
+   sailor.assetcentral.model
    sailor.assetcentral.notification
    sailor.assetcentral.system
    sailor.assetcentral.utils

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -44,7 +44,7 @@ Prerequisites
 ~~~~~~~~~~~~~
 You have cloned the Github project. Every instruction assumes that you are currently in the project folder on your development machine. 
 
-Ideally you have created a dedicated python environment for development with "Sailor". Please check ``python_requires`` in ``setup.py`` for the currently supported python versions and use the most recent eligible version.
+Ideally you have created a dedicated python environment for development with "Sailor". Please check the classifiers in ``setup.py`` for the currently supported python versions and use the most recent eligible version.
 
 
 Installation

--- a/sailor/assetcentral/equipment.py
+++ b/sailor/assetcentral/equipment.py
@@ -30,18 +30,16 @@ if TYPE_CHECKING:
 
 @_add_properties
 class Equipment(AssetcentralEntity):
-    """
-    AssetCentral Equipment Object.
+    """AssetCentral Equipment Object."""
 
-    Properties (in AC terminology) are:
-    equipmentId, name, internalId, status, statusDescription, version, hasInRevision,
-    modelId, modelName, shortDescription, templateId, subclass, modelTemplate,
-    location, criticalityCode, criticalityDescription, manufacturer, completeness, createdOn,
-    changedOn, publishedOn, serialNumber, batchNumber, tagNumber, lifeCycle, lifeCycleDescription,
-    source, imageURL, operator, coordinates, installationDate, equipmentStatus, buildDate,
-    isOperatorValid, modelVersion, soldTo, image, consume, dealer, serviceProvider, primaryExternalId,
-    equipmentSearchTerms, sourceSearchTerms, manufacturerSearchTerms, operatorSearchTerms, class
-    """
+    # Properties (in AC terminology) are:
+    # equipmentId, name, internalId, status, statusDescription, version, hasInRevision,
+    # modelId, modelName, shortDescription, templateId, subclass, modelTemplate,
+    # location, criticalityCode, criticalityDescription, manufacturer, completeness, createdOn,
+    # changedOn, publishedOn, serialNumber, batchNumber, tagNumber, lifeCycle, lifeCycleDescription,
+    # source, imageURL, operator, coordinates, installationDate, equipmentStatus, buildDate,
+    # isOperatorValid, modelVersion, soldTo, image, consume, dealer, serviceProvider, primaryExternalId,
+    # equipmentSearchTerms, sourceSearchTerms, manufacturerSearchTerms, operatorSearchTerms, class
 
     _location = None
 

--- a/sailor/assetcentral/failure_mode.py
+++ b/sailor/assetcentral/failure_mode.py
@@ -12,17 +12,15 @@ from .constants import VIEW_FAILUREMODES
 
 @_add_properties
 class FailureMode(AssetcentralEntity):
-    """
-    AssetCentral Failure Mode Object.
+    """AssetCentral Failure Mode Object."""
 
-    Properties (in AC terminology) are:
-    Client, ID, SubClass, StatusText, SubClassDescription, Type, EquipmentsCount, ModelsCount, SparepartsCount,
-    LocationsCount, GroupsCount, SystemsCount, ObjectCount, DisplayID, Source, SourceID, Version, Consume,
-    CategoryCode, CategoryDescription, Causes, ShortDescription, LongDescription, Status, LastChange, MyFailureMode,
-    Owner, ObjectID, PatternID, PatternConfidence, MTTFValue, MTTFUnit, MTTFConfidence, MTTRValue, MTTRUnit,
-    MTTRConfidence, MTBFValue, MTBFUnit, MTBFConfidence, PatternName, PatternImage, ImageID, PrimaryExternalID,
-    FailureModesSearchTerms, TypeCode, DetectionMethod
-    """
+    # Properties (in AC terminology) are:
+    # Client, ID, SubClass, StatusText, SubClassDescription, Type, EquipmentsCount, ModelsCount, SparepartsCount,
+    # LocationsCount, GroupsCount, SystemsCount, ObjectCount, DisplayID, Source, SourceID, Version, Consume,
+    # CategoryCode, CategoryDescription, Causes, ShortDescription, LongDescription, Status, LastChange, MyFailureMode,
+    # Owner, ObjectID, PatternID, PatternConfidence, MTTFValue, MTTFUnit, MTTFConfidence, MTTRValue, MTTRUnit,
+    # MTTRConfidence, MTBFValue, MTBFUnit, MTBFConfidence, PatternName, PatternImage, ImageID, PrimaryExternalID,
+    # FailureModesSearchTerms, TypeCode, DetectionMethod
 
     @classmethod
     def get_property_mapping(cls):

--- a/sailor/assetcentral/indicators.py
+++ b/sailor/assetcentral/indicators.py
@@ -13,15 +13,14 @@ from .utils import _add_properties, AssetcentralEntity, ResultSet
 
 @_add_properties
 class Indicator(AssetcentralEntity):
-    """
-    AssetCentral Indicator Object.
+    """AssetCentral Indicator Object."""
 
-    Properties (in AC terminology) are: categoryID, propertyId, indicatorGroupName, indicatorName,
-    indicatorGroupDesc, objectId, indicatorSource, aggUpdatedTimestamp, indicatorCategory, colorCode,
-    thresholdDescription, convertedAggregatedValue, trend, dataType, indicatorType, convertedUOMDesc,
-    UOM, convertedUOM, indicatorDesc, indicatorColorCode, isFavorite, UOMDescription, Dimension, DimensionDesc,
-    uomdescription, dimension, dimensionDesc, pstid, uom
-    """  # TODO update field list - I think e.g. template id is also part of hte API response
+    # Properties (in AC terminology) are: categoryID, propertyId, indicatorGroupName, indicatorName,
+    # indicatorGroupDesc, objectId, indicatorSource, aggUpdatedTimestamp, indicatorCategory, colorCode,
+    # thresholdDescription, convertedAggregatedValue, trend, dataType, indicatorType, convertedUOMDesc,
+    # UOM, convertedUOM, indicatorDesc, indicatorColorCode, isFavorite, UOMDescription, Dimension, DimensionDesc,
+    # uomdescription, dimension, dimensionDesc, pstid, uom
+    # TODO update field list - I think e.g. template id is also part of hte API response
 
     @classmethod
     def get_property_mapping(cls):

--- a/sailor/assetcentral/location.py
+++ b/sailor/assetcentral/location.py
@@ -12,13 +12,11 @@ from .constants import VIEW_LOCATIONS
 
 @_add_properties
 class Location(AssetcentralEntity):
-    """
-    AssetCentral Location Object.
+    """AssetCentral Location Object."""
 
-    Properties (in AC terminology) are:
-    locationId, name, status, version, hasInRevision, shortDescription, location, completeness, createdOn,
-    changedOn, publishedOn, source, imageURL, locationStatus, locationTypeDescription, locationType
-    """
+    # Properties (in AC terminology) are:
+    # locationId, name, status, version, hasInRevision, shortDescription, location, completeness, createdOn,
+    # changedOn, publishedOn, source, imageURL, locationStatus, locationTypeDescription, locationType
 
     @classmethod
     def get_property_mapping(cls):

--- a/sailor/assetcentral/model.py
+++ b/sailor/assetcentral/model.py
@@ -21,21 +21,19 @@ if TYPE_CHECKING:
 
 @_add_properties
 class Model(AssetcentralEntity):
-    """
-    AssetCentral Model object.
+    """AssetCentral Model object."""
 
-    Properties (in AC terminology) are:  # as returned by 'models'-api, not model-details
-    modelId, name, internalId, status, version, hasInRevision, templateId, modelTemplate, subclass,
-    generation, manufacturer, shortDescription, longDescription, completeness, createdOn, changedOn,
-    imageURL, publishedOn, source, equipmentTracking, serviceExpirationDate, modelExpirationDate,
-    releaseDate, isManufacturerValid, image, isClientValid, consume, primaryExternalId, modelSearchTerms,
-    sourceSearchTerms, manufacturerSearchTerms, class
+    # Properties (in AC terminology) are:  # as returned by 'models'-api, not model-details
+    # modelId, name, internalId, status, version, hasInRevision, templateId, modelTemplate, subclass,
+    # generation, manufacturer, shortDescription, longDescription, completeness, createdOn, changedOn,
+    # imageURL, publishedOn, source, equipmentTracking, serviceExpirationDate, modelExpirationDate,
+    # releaseDate, isManufacturerValid, image, isClientValid, consume, primaryExternalId, modelSearchTerms,
+    # sourceSearchTerms, manufacturerSearchTerms, class
 
-    Additional properties returned in model-details (again ac terminology, some have sub-structure):
-    organizationID, calibrationDate, orderStopDate, noSparePartsDate, globalId, keywords, safetyRiskCode,
-    description, descriptions[], gtin, brand, isFirmwareCompatible, templates[], classId, subclassId, adminData{},
-    sectionCompleteness{}, modelType, countryCode, referenceId, metadata, templatesDetails[]
-    """
+    # Additional properties returned in model-details (again ac terminology, some have sub-structure):
+    # organizationID, calibrationDate, orderStopDate, noSparePartsDate, globalId, keywords, safetyRiskCode,
+    # description, descriptions[], gtin, brand, isFirmwareCompatible, templates[], classId, subclassId, adminData{},
+    # sectionCompleteness{}, modelType, countryCode, referenceId, metadata, templatesDetails[]
 
     @classmethod
     def get_property_mapping(cls):

--- a/sailor/assetcentral/notification.py
+++ b/sailor/assetcentral/notification.py
@@ -16,19 +16,17 @@ from ..utils.plot_helper import _default_plot_theme
 
 @_add_properties
 class Notification(AssetcentralEntity):
-    """
-    AssetCentral Notification Object.
+    """AssetCentral Notification Object."""
 
-    Properties (in AC terminology) are: notificationId, shortDescription, status, statusDescription, notificationType,
-    notificationTypeDescription, priority, priorityDescription, isInternal, createdBy, creationDateTime,
-    lastChangedBy, lastChangeDateTime, longDescription, startDate, endDate, malfunctionStartDate, malfunctionEndDate,
-    progressStatus, progressStatusDescription, equipmentId, equipmentName, rootEquipmentId, rootEquipmentName,
-    locationId, breakdown, coordinates, source, operatorId, location, assetCoreEquipmentId, operator, internalId,
-    modelId, proposedFailureModeID, proposedFailureModeDisplayID, proposedFailureModeDesc, confirmedFailureModeID,
-    confirmedFailureModeDesc, confirmedFailureModeDisplayIDs, systemProposedFailureModeID,
-    systemProposedFailureModeDesc, systemProposedFailureModeDisplayID, effectID, effectDisplayID, effectDesc,
-    causeID, causeDisplayID, causeDesc, instructionID, instructionTitle
-    """
+    # Properties (in AC terminology) are: notificationId, shortDescription, status, statusDescription, notificationType,
+    # notificationTypeDescription, priority, priorityDescription, isInternal, createdBy, creationDateTime,
+    # lastChangedBy, lastChangeDateTime, longDescription, startDate, endDate, malfunctionStartDate, malfunctionEndDate,
+    # progressStatus, progressStatusDescription, equipmentId, equipmentName, rootEquipmentId, rootEquipmentName,
+    # locationId, breakdown, coordinates, source, operatorId, location, assetCoreEquipmentId, operator, internalId,
+    # modelId, proposedFailureModeID, proposedFailureModeDisplayID, proposedFailureModeDesc, confirmedFailureModeID,
+    # confirmedFailureModeDesc, confirmedFailureModeDisplayIDs, systemProposedFailureModeID,
+    # systemProposedFailureModeDesc, systemProposedFailureModeDisplayID, effectID, effectDisplayID, effectDesc,
+    # causeID, causeDisplayID, causeDesc, instructionID, instructionTitle
 
     @classmethod
     def get_property_mapping(cls):

--- a/sailor/assetcentral/system.py
+++ b/sailor/assetcentral/system.py
@@ -18,14 +18,12 @@ from ..sap_iot import get_indicator_data, TimeseriesDataset
 
 @_add_properties
 class System(AssetcentralEntity):
-    """
-    AssetCentral System Object.
+    """AssetCentral System Object."""
 
-    Properties (in AC terminology) are: systemId, internalId, status, systemStatusDescription, modelID, modelVersion,
-    model, shortDescription, templateID, systemProvider, systemVersion, createdOn, changedOn, source, imageURL,
-    className, classID, subclass, subclassID, systemProviderID, sourceSearchTerms, systemProviderSearchTerms,
-    publishedOn, operator, operatorID, completeness
-    """
+    # Properties (in AC terminology) are: systemId, internalId, status, systemStatusDescription, modelID, modelVersion,
+    # model, shortDescription, templateID, systemProvider, systemVersion, createdOn, changedOn, source, imageURL,
+    # className, classID, subclass, subclassID, systemProviderID, sourceSearchTerms, systemProviderSearchTerms,
+    # publishedOn, operator, operatorID, completeness
 
     def __init__(self, ac_json):
         """Create a new System object and fetch all components."""

--- a/sailor/assetcentral/workorder.py
+++ b/sailor/assetcentral/workorder.py
@@ -11,17 +11,15 @@ from .constants import VIEW_WORKORDERS
 
 @_add_properties
 class Workorder(AssetcentralEntity):
-    """
-    AssetCentral Workorder Object.
+    """AssetCentral Workorder Object."""
 
-    Properties (in AC terminology) are:
-    workOrderID, shortDescription, status, statusDescription, workOrderType, workOrderTypeDescription, priority,
-    priorityDescription, isInternal, createdBy, creationDateTime, lastChangedBy, lastChangeDateTime, longDescription,
-    startDate, endDate, progressStatus, progressStatusDescription, equipmentId, equipmentName, rootEquipmentId,
-    rootEquipmentName, locationId, coordinates, source, sourceId, operatorId, location, isSourceActive,
-    assetCoreEquipmentId, operator, internalId, modelId, plant, workCenter, basicStartDate, basicEndDate,
-    actualStartDate, actualEndDate, personResponsible
-    """
+    # Properties (in AC terminology) are:
+    # workOrderID, shortDescription, status, statusDescription, workOrderType, workOrderTypeDescription, priority,
+    # priorityDescription, isInternal, createdBy, creationDateTime, lastChangedBy, lastChangeDateTime, longDescription,
+    # startDate, endDate, progressStatus, progressStatusDescription, equipmentId, equipmentName, rootEquipmentId,
+    # rootEquipmentName, locationId, coordinates, source, sourceId, operatorId, location, isSourceActive,
+    # assetCoreEquipmentId, operator, internalId, modelId, plant, workCenter, basicStartDate, basicEndDate,
+    # actualStartDate, actualEndDate, personResponsible
 
     @classmethod
     def get_property_mapping(cls):

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     author='DSC Data Science Team',
     author_email='project.sailor@sap.com',
     url='https://github.com/SAP/project-sailor',
-    description=('Easily access data from your SAP Digital Supply Chain software products for data science projects'
+    description=('Easily access data from your SAP Digital Supply Chain software products for data science projects '
                  'like predictive maintenance or master data analysis.'),
     long_description=long_description,
     long_description_content_type='text/x-rst',


### PR DESCRIPTION
- Remove all AC names from docs
- Add space between words in setup.py
- Reorder apidoc module list
- While python_requires is not wrong, classifiers should be maintained too, and is more explicit