### PR TITLE
Add pre-push githook to prevent accidental pushes to main

### DIFF
--- a/.hooks/README.md
+++ b/.hooks/README.md
@@ -1,0 +1,23 @@
+# Git Hooks
+
+From [Git docs](https://git-scm.com/docs/githooks#_description):
+
+> Hooks are programs you can place in a hooks directory to trigger actions at certain points in git’s execution. Hooks that don’t have the executable bit set are ignored.
+
+### Usage
+To use any hook, execute the command provided command in the project root directory to link the script into the `.git/hooks` directory.
+
+
+## Pre-Push Hook
+From [Git docs](https://git-scm.com/docs/githooks#_pre_push):
+
+> This hook is called by git-push and can be used to prevent a push from taking place.
+
+### Content
+Our pre-push hook shall prevent accidental pushes to protected branches like `main` and `gh-pages`.
+
+### Installation
+```sh
+ln -s -f ../../.hooks/pre-push.sh ./.git/hooks/pre-push
+chmod +x .git/hooks/pre-push
+```

--- a/.hooks/pre-push.sh
+++ b/.hooks/pre-push.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# adapted from https://gist.github.com/vlucas/8009a5edadf8d0ff7430
+
+protected_branches=('main' 'gh-pages')
+
+is_destructive='force|delete|\-f'
+
+current_branch=$(git symbolic-ref HEAD | sed -e 's,.*/\(.*\),\1,')
+push_command=$(ps -ocommand= -p $PPID)
+
+do_exit() {
+  printf "[Policy] Never push code directly to the %s branch! (Prevented with pre-push hook.)\n\n" "$protected_branch"
+  exit 1
+}
+
+for protected_branch in "${protected_branches[@]}"; do
+  will_remove_protected_branch=':'$protected_branch
+
+  if [[ $push_command =~ $is_destructive ]] && [ $current_branch = $protected_branch ]; then
+    do_exit
+  fi
+
+  if [[ $push_command =~ $is_destructive ]] && [[ $push_command =~ $protected_branch ]]; then
+    do_exit
+  fi
+
+  if [[ $push_command =~ $will_remove_protected_branch ]]; then
+    do_exit
+  fi
+
+  # Prevent ALL pushes to protected_branch
+  if [[ $push_command =~ $protected_branch ]] || [ $current_branch = $protected_branch ]; then
+    do_exit
+  fi
+done
+
+unset do_exit
+
+exit 0


### PR DESCRIPTION
We want to disable the server-side branch-protection for administrators to allow technical users to push to main.
This hook shall restore safety for our human administrators.