### PR TITLE
Improve API documentation navigation and function listing

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -27,3 +27,7 @@ Disclaimer: The code in this project may include calls to APIs (“API Calls”)
 Files: *
 Copyright:  2020-2021 SAP SE or an SAP affiliate company and project "Sailor" contributors
 License: Apache-2.0
+
+Files: docs/_templates/apidoc/module.rst_t, docs/_templates/apidoc/package.rst_t
+Copyright:  2007-2021 by the Sphinx team.
+License: BSD-2-Clause

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -29,5 +29,5 @@ Copyright:  2020-2021 SAP SE or an SAP affiliate company and project "Sailor" co
 License: Apache-2.0
 
 Files: docs/_templates/apidoc/module.rst_t, docs/_templates/apidoc/package.rst_t
-Copyright:  2007-2021 by the Sphinx team.
+Copyright:  2007-2021 by the Sphinx team. Modifications 2021 SAP SE or an SAP affiliate company and project "Sailor" contributors
 License: BSD-2-Clause

--- a/LICENSE
+++ b/LICENSE
@@ -175,18 +175,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2020-2021 SAP SE or an SAP affiliate company and project "Sailor" contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSES/BSD-2-Clause.txt
+++ b/LICENSES/BSD-2-Clause.txt
@@ -1,0 +1,9 @@
+Copyright (c) <year> <owner> All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.rst
+++ b/README.rst
@@ -146,3 +146,8 @@ Contributing
 ============
 
 We welcome all contributions either in form of issues, code contributions, questions or any other formats. For details please refer to the `Contributing Page <https://sap.github.io/project-sailor/contributing.html>`__ in the documentation.
+
+
+Licensing
+=========
+Please see our `LICENSE <https://github.com/SAP/project-sailor/blob/main/LICENSE>`__ for copyright and license information. Detailed information including third-party components and their licensing/copyright information is available via the `REUSE tool <https://api.reuse.software/info/github.com/SAP/project-sailor>`__.

--- a/docs/_templates/apidoc/package.rst_t
+++ b/docs/_templates/apidoc/package.rst_t
@@ -1,0 +1,53 @@
+{%- macro automodule(modname, options) -%}
+.. automodule:: {{ modname }}
+{%- for option in options %}
+   :{{ option }}:
+{%- endfor %}
+{%- endmacro %}
+
+{%- macro toctree(docnames) -%}
+.. toctree::
+   :maxdepth: {{ maxdepth }}
+{% for docname in docnames %}
+   {{ docname }}
+{%- endfor %}
+{%- endmacro %}
+
+{%- if is_namespace %}
+{{- [pkgname, "namespace"] | join(" ") | e | heading }}
+{% else %}
+{{- [":mod:", "`", pkgname | e, "`"] | join("") | heading }}
+{% endif %}
+
+{%- if modulefirst and not is_namespace %}
+{{ automodule(pkgname, automodule_options) }}
+{% endif %}
+
+{%- if subpackages %}
+Subpackages
+-----------
+
+{{ toctree(subpackages) }}
+{% endif %}
+
+{%- if submodules %}
+Submodules
+----------
+{% if separatemodules %}
+{{ toctree(submodules) }}
+{% else %}
+{%- for submodule in submodules %}
+{% if show_headings %}
+{{- [submodule, "module"] | join(" ") | e | heading(2) }}
+{% endif %}
+{{ automodule(submodule, automodule_options) }}
+{% endfor %}
+{%- endif %}
+{%- endif %}
+
+{%- if not modulefirst and not is_namespace %}
+Module contents
+---------------
+
+{{ automodule(pkgname, automodule_options) }}
+{% endif %}

--- a/docs/apidoc.rst
+++ b/docs/apidoc.rst
@@ -4,6 +4,6 @@ API documentation
 .. toctree::
    :glob:
 
-   apidoc/sailor.assetcentral.*
-   apidoc/sailor.sap_iot.*
+   apidoc/sailor.assetcentral
+   apidoc/sailor.sap_iot
 

--- a/docs/apidoc.rst
+++ b/docs/apidoc.rst
@@ -2,7 +2,6 @@ API documentation
 =================
 
 .. toctree::
-   :glob:
 
    apidoc/sailor.assetcentral
    apidoc/sailor.sap_iot

--- a/docs/apidoc/sailor.assetcentral.rst
+++ b/docs/apidoc/sailor.assetcentral.rst
@@ -1,5 +1,5 @@
-sailor.assetcentral package
-===========================
+:mod:`sailor.assetcentral`
+==========================
 
 Submodules
 ----------

--- a/docs/apidoc/sailor.rst
+++ b/docs/apidoc/sailor.rst
@@ -1,5 +1,5 @@
-sailor package
-==============
+:mod:`sailor`
+=============
 
 Subpackages
 -----------

--- a/docs/apidoc/sailor.sap_iot.rst
+++ b/docs/apidoc/sailor.sap_iot.rst
@@ -1,5 +1,5 @@
-sailor.sap\_iot package
-=======================
+:mod:`sailor.sap\_iot`
+======================
 
 Submodules
 ----------

--- a/docs/apidoc/sailor.utils.oauth_wrapper.constants.rst
+++ b/docs/apidoc/sailor.utils.oauth_wrapper.constants.rst
@@ -1,6 +1,0 @@
-:mod:`sailor.utils.oauth\_wrapper.constants`
-============================================
-
-.. automodule:: sailor.utils.oauth_wrapper.constants
-   :members:
-   :show-inheritance:

--- a/docs/apidoc/sailor.utils.oauth_wrapper.rst
+++ b/docs/apidoc/sailor.utils.oauth_wrapper.rst
@@ -1,5 +1,5 @@
-sailor.utils.oauth\_wrapper package
-===================================
+:mod:`sailor.utils.oauth\_wrapper`
+==================================
 
 Submodules
 ----------
@@ -8,7 +8,6 @@ Submodules
    :maxdepth: 4
 
    sailor.utils.oauth_wrapper.OAuthServiceImpl
-   sailor.utils.oauth_wrapper.constants
    sailor.utils.oauth_wrapper.scope_config
 
 Module contents

--- a/docs/apidoc/sailor.utils.rst
+++ b/docs/apidoc/sailor.utils.rst
@@ -1,5 +1,5 @@
-sailor.utils package
-====================
+:mod:`sailor.utils`
+===================
 
 Subpackages
 -----------

--- a/sailor/assetcentral/__init__.py
+++ b/sailor/assetcentral/__init__.py
@@ -1,7 +1,10 @@
-from .equipment import find_equipment  # noqa: F401
-from .model import find_models  # noqa: F401
-from .failure_mode import find_failure_modes  # noqa: F401
-from .location import find_locations  # noqa: F401
-from .notification import find_notifications  # noqa: F401
-from .system import find_systems  # noqa: F401
-from .workorder import find_workorders  # noqa: F401
+from .equipment import find_equipment
+from .model import find_models
+from .failure_mode import find_failure_modes
+from .location import find_locations
+from .notification import find_notifications
+from .system import find_systems
+from .workorder import find_workorders
+
+__all__ = ['find_equipment', 'find_models', 'find_failure_modes', 'find_locations', 'find_notifications',
+           'find_systems', 'find_workorders']


### PR DESCRIPTION
- List available "find functions" in `__all__` assetcentral package `__init__.py`
- Now these imports will show up in the package documentation
- Show packages instead of modules in the API documentation, so that the reader can easily find the "find functions" in the assetcentral package documentation
- Fix/add LICENSE information