### PR TITLE
fix short scope extensions for IoT

### DIFF
--- a/sailor/utils/oauth_wrapper/scope_config.py
+++ b/sailor/utils/oauth_wrapper/scope_config.py
@@ -11,5 +11,5 @@
 # }
 #
 SCOPE_CONFIG = {
-    'sap_iot': ['t1.am.ts.r', 't1.am.ts.cud', 't1.r', 't1.am.map.r', 't1.export.r']
+    'sap_iot': ['.am.ts.r', '.am.ts.cud', '.r', '.am.map.r', '.export.r']
 }


### PR DESCRIPTION
@ww917352 just let me know that `t1` should not be part of the short scopes, as it changes from one landscape/deployment to another.