### PR TITLE
Fix _fetch_data remote call without filters

### DIFF
--- a/sailor/assetcentral/utils.py
+++ b/sailor/assetcentral/utils.py
@@ -128,17 +128,17 @@ def _fetch_data(endpoint_url, unbreakable_filters=(), breakable_filters=()):
     service = OAuthFlow('asset_central')
 
     if not filters:
-        result = service.fetch_endpoint_data(endpoint_url, method='GET')
-    else:
-        result = []
-        for filter_string in filters:
-            parameters = {'$filter': filter_string} if filter_string else None
-            endpoint_data = service.fetch_endpoint_data(endpoint_url, method='GET', parameters=parameters)
+        filters = ['']
 
-            if isinstance(endpoint_data, list):
-                result.extend(endpoint_data)
-            else:
-                result.append(endpoint_data)
+    result = []
+    for filter_string in filters:
+        parameters = {'$filter': filter_string} if filter_string else None
+        endpoint_data = service.fetch_endpoint_data(endpoint_url, method='GET', parameters=parameters)
+
+        if isinstance(endpoint_data, list):
+            result.extend(endpoint_data)
+        else:
+            result.append(endpoint_data)
 
     if len(result) == 0:
         warnings.warn(DataNotFoundWarning(), stacklevel=2)

--- a/sailor/assetcentral/utils.py
+++ b/sailor/assetcentral/utils.py
@@ -127,15 +127,18 @@ def _fetch_data(endpoint_url, unbreakable_filters=(), breakable_filters=()):
     filters = _compose_queries(unbreakable_filters, breakable_filters)
     service = OAuthFlow('asset_central')
 
-    result = []
-    for filter_string in filters:
-        parameters = {'$filter': filter_string} if filter_string else None
-        endpoint_data = service.fetch_endpoint_data(endpoint_url, method='GET', parameters=parameters)
+    if not filters:
+        result = service.fetch_endpoint_data(endpoint_url, method='GET')
+    else:
+        result = []
+        for filter_string in filters:
+            parameters = {'$filter': filter_string} if filter_string else None
+            endpoint_data = service.fetch_endpoint_data(endpoint_url, method='GET', parameters=parameters)
 
-        if isinstance(endpoint_data, list):
-            result.extend(endpoint_data)
-        else:
-            result.append(endpoint_data)
+            if isinstance(endpoint_data, list):
+                result.extend(endpoint_data)
+            else:
+                result.append(endpoint_data)
 
     if len(result) == 0:
         warnings.warn(DataNotFoundWarning(), stacklevel=2)

--- a/tests/test_sailor/test_assetcentral/test_utils.py
+++ b/tests/test_sailor/test_assetcentral/test_utils.py
@@ -298,12 +298,14 @@ class TestComposeQueries:
 class TestFetchData:
     @patch('sailor.assetcentral.utils.OAuthFlow', return_value=Mock(OAuthFlow))
     @pytest.mark.filterwarnings('ignore::sailor.utils.utils.DataNotFoundWarning')
-    @pytest.mark.parametrize('testdesc,unbreakable_filters,breakable_filters', [
-        ('no filters', [], []),
-        ('filters', ['a gt b'], [['c eq 1']])
+    @pytest.mark.parametrize('testdesc,unbreakable_filters,breakable_filters,remote_return', [
+        ('no filters - single return', [], [], {'a': 'dict'}),
+        ('filters - single return', ['a gt b'], [['c eq 1']], {'a': 'dict'}),
+        ('no filters - list return', [], [], ['result']),
+        ('filters - list return', ['a gt b'], [['c eq 1']], ['result']),
     ])
-    def test_returns_iterable(self, auth_mock, unbreakable_filters, breakable_filters, testdesc):
-        auth_mock.return_value.fetch_endpoint_data.return_value = []
+    def test_returns_iterable(self, auth_mock, unbreakable_filters, breakable_filters, remote_return, testdesc):
+        auth_mock.return_value.fetch_endpoint_data.return_value = remote_return
         actual = _fetch_data('', unbreakable_filters, breakable_filters)
         assert not issubclass(actual.__class__, str)
         assert isinstance(actual, Iterable)

--- a/tests/test_sailor/test_assetcentral/test_utils.py
+++ b/tests/test_sailor/test_assetcentral/test_utils.py
@@ -309,7 +309,7 @@ class TestFetchData:
         assert isinstance(actual, Iterable)
 
     @patch('sailor.assetcentral.utils.OAuthFlow', return_value=Mock(OAuthFlow))
-    def test_no_filters_makes_remote_call(self, auth_mock):
+    def test_no_filters_makes_remote_call_with_no_params(self, auth_mock):
         fetch_mock = auth_mock.return_value.fetch_endpoint_data
         fetch_mock.return_value = ['result']
         unbreakable_filters = []
@@ -317,7 +317,7 @@ class TestFetchData:
 
         actual = _fetch_data('', unbreakable_filters, breakable_filters)
 
-        fetch_mock.assert_called_once_with('', method='GET')
+        fetch_mock.assert_called_once_with('', method='GET', parameters=None)
         assert actual == ['result']
 
     @patch('sailor.assetcentral.utils.OAuthFlow', return_value=Mock(OAuthFlow))


### PR DESCRIPTION
_fetch_data does not make a remote call when called without filters.
This bug was introduced when fixing the _compose_queries method.
This behaviour is now secured with a test.