### PR TITLE
Support Python 3.9 by adding automated tests

### DIFF
--- a/.github/workflows/main_validation.yml
+++ b/.github/workflows/main_validation.yml
@@ -1,0 +1,27 @@
+name: Validation
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.9']
+
+    steps:
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: |
+          pip install pytest
+          pip install -r requirements.txt
+
+      - name: Run pytest
+        run: pytest

--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ Requirements
 
 You need access to SAP Asset Central and the SAP IoT services in order to use "Sailor".
 
-Since the project "Sailor" is implemented in Python you need to have Python installed. Currently we support Python 3.8.
+Since the project "Sailor" is implemented in Python you need to have Python installed. Currently we support Python >=3.8.
 The required python packages are automatically installed while installing "Sailor".
 
 

--- a/setup.py
+++ b/setup.py
@@ -23,12 +23,13 @@ setup(
     keywords='',
     license='',
     packages=find_packages(include=('sailor', 'sailor.*')),
-    python_requires='~=3.8',
+    python_requires='>=3.8',
     install_requires=install_requires,
     classifiers=[
         'Development Status :: 4 - Beta',
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
     project_urls={  # Optional
         'Documentation': 'https://sap.github.io/project-sailor',


### PR DESCRIPTION
Commits on main are checked by running pytests automatically.
These tests run for all supported python versions.

As a result, we can support Python 3.9 officially.