### PR TITLE
Fix circular import problems

### DIFF
--- a/sailor/assetcentral/equipment.py
+++ b/sailor/assetcentral/equipment.py
@@ -10,6 +10,7 @@ from datetime import datetime
 
 import pandas as pd
 
+from sailor import sap_iot
 from .constants import VIEW_EQUIPMENT, VIEW_OBJECTS
 from .failure_mode import find_failure_modes
 from .indicators import Indicator, IndicatorSet
@@ -19,7 +20,6 @@ from .workorder import find_workorders
 from .utils import _fetch_data, _add_properties, _parse_filter_parameters, AssetcentralEntity, ResultSet, \
     _ac_application_url, _apply_filters_post_request
 from ..utils.timestamps import _string_to_timestamp_parser
-from ..sap_iot import get_indicator_data
 
 if TYPE_CHECKING:
     from ..sap_iot import TimeseriesDataset
@@ -180,7 +180,7 @@ class Equipment(AssetcentralEntity):
 
     def get_indicator_data(self, start: Union[str, pd.Timestamp, datetime.timestamp, datetime.date],
                            end: Union[str, pd.Timestamp, datetime.timestamp, datetime.date],
-                           indicator_set: IndicatorSet = None) -> TimeseriesDataset:
+                           indicator_set: IndicatorSet = None) -> 'TimeseriesDataset':
         """
         Fetch timeseries data from SAP Internet of Things for Indicators attached to this equipment.
 
@@ -213,7 +213,7 @@ class Equipment(AssetcentralEntity):
         if indicator_set is None:
             indicator_set = self.find_equipment_indicators()
 
-        return get_indicator_data(start, end, indicator_set, EquipmentSet([self]))
+        return sap_iot.get_indicator_data(start, end, indicator_set, EquipmentSet([self]))
 
 
 class EquipmentSet(ResultSet):
@@ -318,7 +318,7 @@ class EquipmentSet(ResultSet):
 
     def get_indicator_data(self, start: Union[str, pd.Timestamp, datetime.timestamp, datetime.date],
                            end: Union[str, pd.Timestamp, datetime.timestamp, datetime.date],
-                           indicator_set: IndicatorSet = None) -> TimeseriesDataset:
+                           indicator_set: IndicatorSet = None) -> 'TimeseriesDataset':
         """
         Fetch timeseries data from SAP Internet of Things for Indicators attached to all equipments in this set.
 
@@ -351,7 +351,7 @@ class EquipmentSet(ResultSet):
         if indicator_set is None:
             indicator_set = self.find_common_indicators()
 
-        return get_indicator_data(start, end, indicator_set, self)
+        return sap_iot.get_indicator_data(start, end, indicator_set, self)
 
 
 def find_equipment(*, extended_filters=(), **kwargs) -> EquipmentSet:

--- a/sailor/assetcentral/equipment.py
+++ b/sailor/assetcentral/equipment.py
@@ -180,7 +180,7 @@ class Equipment(AssetcentralEntity):
 
     def get_indicator_data(self, start: Union[str, pd.Timestamp, datetime.timestamp, datetime.date],
                            end: Union[str, pd.Timestamp, datetime.timestamp, datetime.date],
-                           indicator_set: IndicatorSet = None) -> 'TimeseriesDataset':
+                           indicator_set: IndicatorSet = None) -> TimeseriesDataset:
         """
         Fetch timeseries data from SAP Internet of Things for Indicators attached to this equipment.
 
@@ -318,7 +318,7 @@ class EquipmentSet(ResultSet):
 
     def get_indicator_data(self, start: Union[str, pd.Timestamp, datetime.timestamp, datetime.date],
                            end: Union[str, pd.Timestamp, datetime.timestamp, datetime.date],
-                           indicator_set: IndicatorSet = None) -> 'TimeseriesDataset':
+                           indicator_set: IndicatorSet = None) -> TimeseriesDataset:
         """
         Fetch timeseries data from SAP Internet of Things for Indicators attached to all equipments in this set.
 

--- a/sailor/assetcentral/notification.py
+++ b/sailor/assetcentral/notification.py
@@ -7,6 +7,7 @@ Classes are provided for individual Notifications as well as groups of Notificat
 import pandas as pd
 import plotnine as p9
 
+import sailor.assetcentral.equipment
 from .constants import VIEW_NOTIFICATIONS
 from .utils import _fetch_data, _add_properties, ResultSet, _parse_filter_parameters,\
     AssetcentralEntity, _ac_application_url
@@ -80,10 +81,7 @@ class Notification(AssetcentralEntity):
         window_after
             Time interval plotted after a notification. Default value is 2 days after a notification
         """
-        # required to avoid circular imports. which is aweful. not sure about the best way to approach this though
-        from .equipment import find_equipment
-
-        equipment_set = find_equipment(id=self.equipment_id)
+        equipment_set = sailor.assetcentral.equipment.find_equipment(id=self.equipment_id)
 
         if self.start_date and self.end_date:
             data_start = self.start_date - window_before

--- a/sailor/assetcentral/system.py
+++ b/sailor/assetcentral/system.py
@@ -3,6 +3,8 @@ System module can be used to retrieve System information from AssetCentral.
 
 Classes are provided for individual Systems as well as groups of Systems (SystemSet).
 """
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Union
 from datetime import datetime
 
@@ -63,7 +65,7 @@ class System(AssetcentralEntity):
             self.components = EquipmentSet([])
 
     def get_indicator_data(self, start: Union[str, pd.Timestamp, datetime.timestamp, datetime.date],
-                           end: Union[str, pd.Timestamp, datetime.timestamp, datetime.date]) -> 'TimeseriesDataset':
+                           end: Union[str, pd.Timestamp, datetime.timestamp, datetime.date]) -> TimeseriesDataset:
         """
         Get timeseries data for all Equipment in the System.
 
@@ -96,7 +98,7 @@ class SystemSet(ResultSet):
     }
 
     def get_indicator_data(self, start: Union[str, pd.Timestamp, datetime.timestamp, datetime.date],
-                           end: Union[str, pd.Timestamp, datetime.timestamp, datetime.date]) -> 'TimeseriesDataset':
+                           end: Union[str, pd.Timestamp, datetime.timestamp, datetime.date]) -> TimeseriesDataset:
         """
         Fetch data for a set of systems for all component equipment of each system.
 

--- a/sailor/sap_iot/fetch.py
+++ b/sailor/sap_iot/fetch.py
@@ -67,8 +67,7 @@ def _check_bulk_timeseries_export_status(export_id: str) -> bool:
         raise RuntimeError(resp['Status'])
 
 
-def _process_one_file(ifile: BinaryIO, indicator_set: IndicatorSet, equipment_set: EquipmentSet) \
-                      -> pd.DataFrame:
+def _process_one_file(ifile: BinaryIO, indicator_set: IndicatorSet, equipment_set: EquipmentSet) -> pd.DataFrame:
     # each processed file contains data for some time range (one day it seems), one indicator group and all
     # equipment_set holding any data for that group in that time period.
     # Since the user might not have requested all indicators in the group we'll filter out any results that were not

--- a/sailor/sap_iot/wrappers.py
+++ b/sailor/sap_iot/wrappers.py
@@ -18,12 +18,12 @@ from plotnine.themes import theme
 from plotnine.scales import scale_x_datetime
 from sklearn.preprocessing import StandardScaler
 
+import sailor.assetcentral.indicators as ac_indicators
 from ..utils.plot_helper import _default_plot_theme
 from ..utils.timestamps import _any_to_timestamp, _calculate_nice_sub_intervals
-from ..assetcentral.indicators import AggregatedIndicator, AggregatedIndicatorSet
 
 if TYPE_CHECKING:
-    from ..assetcentral.indicators import IndicatorSet
+    from ..assetcentral.indicators import IndicatorSet, AggregatedIndicatorSet
     from ..assetcentral.equipment import EquipmentSet
 
 LOG = logging.getLogger(__name__)
@@ -387,10 +387,10 @@ class TimeseriesDataset(object):
         aggregation_definition = {}
         for indicator in self._indicator_set:
             for aggregation_function in aggregation_functions:
-                new_indicator = AggregatedIndicator(indicator.raw, str(aggregation_function))
+                new_indicator = ac_indicators.AggregatedIndicator(indicator.raw, str(aggregation_function))
                 new_indicators.append(new_indicator)
                 aggregation_definition[new_indicator._unique_id] = (indicator._unique_id, aggregation_function)
-        new_indicator_set = AggregatedIndicatorSet(new_indicators)
+        new_indicator_set = ac_indicators.AggregatedIndicatorSet(new_indicators)
 
         grouper = [*self.get_key_columns(),
                    pd.Grouper(key=self.get_time_column(), closed='left', freq=aggregation_interval)]

--- a/sailor/sap_iot/wrappers.py
+++ b/sailor/sap_iot/wrappers.py
@@ -23,7 +23,7 @@ from ..utils.plot_helper import _default_plot_theme
 from ..utils.timestamps import _any_to_timestamp, _calculate_nice_sub_intervals
 
 if TYPE_CHECKING:
-    from ..assetcentral.indicators import IndicatorSet, AggregatedIndicatorSet
+    from ..assetcentral.indicators import IndicatorSet
     from ..assetcentral.equipment import EquipmentSet
 
 LOG = logging.getLogger(__name__)
@@ -244,7 +244,7 @@ class TimeseriesDataset(object):
             indicator=lambda x: x.Feature.apply(lambda row: name_mapping[row][2])
         )
 
-        if isinstance(self._indicator_set, AggregatedIndicatorSet):
+        if isinstance(self._indicator_set, ac_indicators.AggregatedIndicatorSet):
             facet_grid_definition = 'aggregation + indicator + template + indicator_group ~ .'
             facet_assignment['aggregation'] = lambda x: x.Feature.apply(lambda row: name_mapping[row][3])
 


### PR DESCRIPTION
sap_iot and assetcentral modules import each other and when one name (function, class, etc..) is imported in both modules a circular import happens.

Fix by removing explicit names and using absolut imports of the modules.
For type checking the explicit import of names can still be used if we want to (done here).

Additionally fixing an old workaround in notification.py along the way.