### PR TITLE
always return str data type for key columns in _process_one_file

### DIFF
--- a/sailor/sap_iot/fetch.py
+++ b/sailor/sap_iot/fetch.py
@@ -79,6 +79,7 @@ def _process_one_file(ifile: BinaryIO, indicator_set: IndicatorSet, equipment_se
     df = pd.read_csv(ifile)
 
     df['_TIME'] = pd.to_datetime(df['_TIME'], utc=True, unit='ms', errors='coerce')
+    df = df.astype({'equipmentId': str, 'modelId': str, 'indicatorGroupId': str, 'templateId': str})
     df = df.pivot(index=['_TIME', 'equipmentId', 'modelId'], columns=['indicatorGroupId', 'templateId'])
 
     columns_to_keep = {}


### PR DESCRIPTION
@LeenaPajo this should fix the issue you have been seeing, I think I prefer this solution to the `if not data.empty` approach.
@cloudyday 