### PR TITLE
Improve client handling and refactor OAuth client

### DIFF
--- a/sailor/assetcentral/utils.py
+++ b/sailor/assetcentral/utils.py
@@ -12,7 +12,7 @@ import re
 import pandas as pd
 import plotnine as p9
 
-from ..utils.oauth_wrapper import OAuthFlow
+from ..utils.oauth_wrapper import get_oauth_client
 from ..utils.plot_helper import _default_plot_theme
 from ..utils.config import SailorConfig
 from ..utils.utils import DataNotFoundWarning
@@ -125,7 +125,7 @@ def _compose_queries(unbreakable_filters, breakable_filters):
 def _fetch_data(endpoint_url, unbreakable_filters=(), breakable_filters=()):
     """Retrieve data from the AssetCentral service."""
     filters = _compose_queries(unbreakable_filters, breakable_filters)
-    service = OAuthFlow('asset_central')
+    service = get_oauth_client('asset_central')
 
     if not filters:
         filters = ['']

--- a/sailor/sap_iot/fetch.py
+++ b/sailor/sap_iot/fetch.py
@@ -21,8 +21,8 @@ from io import BytesIO
 import pandas as pd
 
 import sailor.assetcentral.indicators as ac_indicators
+from ..utils.oauth_wrapper import get_oauth_client, RequestError
 from ..utils.timestamps import _any_to_timestamp, _timestamp_to_date_string
-from ..utils.oauth_wrapper import OAuthFlow, RequestError
 from ..utils.config import SailorConfig
 from .wrappers import TimeseriesDataset
 from ..utils.utils import DataNotFoundWarning
@@ -43,7 +43,7 @@ fixed_timeseries_columns = {
 
 def _start_bulk_timeseries_data_export(start_date: str, end_date: str, liot_indicator_group: str) -> str:
     LOG.debug("Triggering raw indicator data export for indicator group: %s.", liot_indicator_group)
-    oauth_iot = OAuthFlow('sap_iot')
+    oauth_iot = get_oauth_client('sap_iot')
     base_url = SailorConfig.get('sap_iot', 'export_url')  # todo: figure out what to do about these urls
     request_url = f'{base_url}/v1/InitiateDataExport/{liot_indicator_group}?timerange={start_date}-{end_date}'
 
@@ -53,7 +53,7 @@ def _start_bulk_timeseries_data_export(start_date: str, end_date: str, liot_indi
 
 def _check_bulk_timeseries_export_status(export_id: str) -> bool:
     LOG.debug("Checking export status for export id: %s.", export_id)
-    oauth_iot = OAuthFlow('sap_iot')
+    oauth_iot = get_oauth_client('sap_iot')
     base_url = SailorConfig.get('sap_iot', 'export_url')  # todo: figure out what to do about these urls
     request_url = f'{base_url}/v1/DataExportStatus?requestId={export_id}'
 
@@ -106,7 +106,7 @@ def _process_one_file(ifile: BinaryIO, indicator_set: IndicatorSet, equipment_se
 def _get_exported_bulk_timeseries_data(export_id: str,
                                        indicator_set: IndicatorSet,
                                        equipment_set: EquipmentSet) -> pd.DataFrame:
-    oauth_iot = OAuthFlow('sap_iot')
+    oauth_iot = get_oauth_client('sap_iot')
     base_url = SailorConfig.get('sap_iot', 'download_url')  # todo: figure out what to do about these urls
     request_url = f"{base_url}/v1/DownloadData('{export_id}')"
 

--- a/sailor/utils/oauth_wrapper/OAuthServiceImpl.py
+++ b/sailor/utils/oauth_wrapper/OAuthServiceImpl.py
@@ -64,7 +64,7 @@ class OAuthFlow:
             try:
                 self._resolve_configured_scopes()
             except Exception as exc:
-                warnings.warn("Could not resolve the configured scopes. Trying to continue without scopes...")
+                warnings.warn('Could not resolve the configured scopes. Trying to continue without scopes...')
                 LOG.debug(exc, exc_info=True)
 
         if self.resolved_scopes:
@@ -80,7 +80,7 @@ class OAuthFlow:
         endpoint_url.args = {**endpoint_url.args, **parameters}
         endpoint_url = endpoint_url.tostr(query_quote_plus=False)
 
-        LOG.debug("Calling %s", endpoint_url)
+        LOG.debug('Calling %s', endpoint_url)
         response = session.request(method, endpoint_url)
         if response.ok:
             if response.headers['Content-Type'] == 'application/json':
@@ -102,19 +102,19 @@ class OAuthFlow:
         if self._active_session:
             use_active_session = True
             decoded_token = jwt.decode(self._active_session.access_token_response.json()['access_token'],
-                                       options={"verify_signature": False})
+                                       options={'verify_signature': False})
             expiration_time = datetime.fromtimestamp(decoded_token['exp'])
             if expiration_time - datetime.utcnow() < timedelta(minutes=5):
-                LOG.debug("OAuth session expires at %s", expiration_time)
+                LOG.debug('OAuth session expires at %s', expiration_time)
                 use_active_session = False
             elif params is not None and 'scope' in params:
                 if sorted(decoded_token['scope']) != sorted(params['scope'].split(' ')):
                     use_active_session = False
-                    LOG.debug("Scopes are not identical.")
+                    LOG.debug('Scopes are not identical.')
             if use_active_session:
                 return self._active_session
 
-        LOG.debug("Creating new OAuth session for '%s'", self.name)
+        LOG.debug('Creating new OAuth session for "%s"', self.name)
         if not params:
             params = {'grant_type': 'client_credentials'}
         service = OAuth2Service(name=self.name, client_id=self.client_id, client_secret=self.client_secret,
@@ -122,7 +122,7 @@ class OAuthFlow:
         # the get_auth_session method of rauth does not check whether the response was 200 or not
         # and therefore does not log a proper error message
         self._active_session = service.get_auth_session('POST', data=params, decoder=json.loads)
-        self._active_session.headers = {"Accept": "application/json"}
+        self._active_session.headers = {'Accept': 'application/json'}
         return self._active_session
 
     def _resolve_configured_scopes(self):
@@ -139,7 +139,7 @@ class OAuthFlow:
             return
 
         encoded_token = self._get_session().access_token_response.json()['access_token']
-        decoded_token = jwt.decode(encoded_token, options={"verify_signature": False})
+        decoded_token = jwt.decode(encoded_token, options={'verify_signature': False})
         all_scopes = decoded_token['scope']
 
         resolved_scopes = []
@@ -160,8 +160,8 @@ class OAuthFlow:
         # we consider the scope configuration invalid when at least one
         # corresponding prefixed scope from auth token is absent
         if missing_corresponding_scopes:
-            warnings.warn("Could not resolve all scopes. Scope configuration considered invalid. " +
-                          f"Continuing without resolved scopes. Missing scopes: {missing_corresponding_scopes}.")
+            warnings.warn('Could not resolve all scopes. Scope configuration considered invalid. ' +
+                          f'Continuing without resolved scopes. Missing scopes: {missing_corresponding_scopes}.')
             self.resolved_scopes = []
         else:
             self.resolved_scopes = resolved_scopes

--- a/sailor/utils/oauth_wrapper/__init__.py
+++ b/sailor/utils/oauth_wrapper/__init__.py
@@ -1,2 +1,3 @@
 from .OAuthServiceImpl import OAuthFlow  # noqa: F401
 from .OAuthServiceImpl import RequestError  # noqa: F401
+from .clients import get_oauth_client  # noqa: F401

--- a/sailor/utils/oauth_wrapper/clients.py
+++ b/sailor/utils/oauth_wrapper/clients.py
@@ -1,0 +1,19 @@
+"""Stores and returns OAuth clients."""
+import logging
+
+from .OAuthServiceImpl import OAuthFlow
+
+LOG = logging.getLogger(__name__)
+LOG.addHandler(logging.NullHandler())
+
+_clients = {}
+
+
+def get_oauth_client(name) -> OAuthFlow:
+    """Return an existing OAuth client or create a new one based on the name."""
+    if name in _clients:
+        return _clients[name]
+
+    LOG.debug("Creating new OAuth client for '%s'", name)
+    _clients[name] = OAuthFlow(name)
+    return _clients[name]

--- a/tests/test_sailor/test_utils/test_oauth_flow.py
+++ b/tests/test_sailor/test_utils/test_oauth_flow.py
@@ -63,7 +63,7 @@ def test_scopes_config_not_available():
 
     oauth_flow = OAuthFlow('test_service', scope_config)
     oauth_flow._resolve_configured_scopes()
-    assert oauth_flow.resolved_scopes == [], "OAuthFlow must not have scopes"
+    assert oauth_flow.resolved_scopes == [], 'OAuthFlow must not have scopes'
 
 
 def test_scopes_config_available_token_available():
@@ -82,7 +82,7 @@ def test_scopes_config_available_token_available():
         oauth_flow._resolve_configured_scopes()
 
     assert oauth_flow.resolved_scopes == ['foo!scope1', 'bar!scope2', 'foobar!scope3'], (
-        "Scopes have been resolved incorrectly")
+        'Scopes have been resolved incorrectly')
     mock_method.assert_called_once()
 
 
@@ -97,7 +97,7 @@ def test_scopes_config_available_getting_token_fails():
         with pytest.raises(Exception):
             oauth_flow._resolve_configured_scopes()
 
-    assert oauth_flow.resolved_scopes == [], "Scopes must be empty"
+    assert oauth_flow.resolved_scopes == [], 'Scopes must be empty'
     mock_method.assert_called_once()
 
 
@@ -114,5 +114,5 @@ def test_scopes_config_available_decoding_token_fails(jwt_decode_mock):
         with pytest.warns(UserWarning, match=r'Could not resolve all scopes'):
             oauth_flow._resolve_configured_scopes()
 
-    assert oauth_flow.resolved_scopes == [], "Scopes must be empty"
+    assert oauth_flow.resolved_scopes == [], 'Scopes must be empty'
     mock_method.assert_called_once()

--- a/tests/test_sailor/test_utils/test_oauth_flow.py
+++ b/tests/test_sailor/test_utils/test_oauth_flow.py
@@ -55,8 +55,9 @@ def test_fetch_endpoint_data():
         result_data = oauth_flow.fetch_endpoint_data('https://some-service-url.to/api/resource', 'GET')
 
     assert expected_data == result_data
-    params = get_session_mock.call_args[0][0]
-    assert params['scope'] == ' '.join(full_scopes), 'Wrong scopes provided to oauth session'
+    assert 'scope' in get_session_mock.call_args[-1]
+    actual_scope = get_session_mock.call_args[-1]['scope']
+    assert actual_scope == ' '.join(full_scopes), 'Wrong scopes provided to oauth session'
 
 
 def test_scopes_config_not_available():
@@ -137,13 +138,13 @@ def test_get_session_returns_active_session_on_repeated_calls(get_auth_mock, dec
                                    'scope': ['test']})
 @patch('rauth.OAuth2Service.get_auth_session')
 def test_get_session_returns_new_session_if_scopes_are_different(get_auth_mock, decode_mock):
-    params = {'scope': 'abc def'}
+    new_scopes_requested = 'abc def'
     expected_session = MagicMock()
     get_auth_mock.return_value = expected_session
     oauth_flow = OAuthFlow('test_service')
     oauth_flow._active_session = MagicMock()
 
-    actual = oauth_flow._get_session(params)
+    actual = oauth_flow._get_session(scope=new_scopes_requested)
 
     get_auth_mock.assert_called_once()
     assert actual == expected_session

--- a/tests/test_sailor/test_utils/test_oauth_flow.py
+++ b/tests/test_sailor/test_utils/test_oauth_flow.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from unittest import TestCase
 from unittest.mock import patch, Mock
 
 import jwt
@@ -9,127 +8,111 @@ import pytest
 from sailor.utils.oauth_wrapper.OAuthServiceImpl import OAuthFlow
 
 
-class TestOAuthFlow(TestCase):
-    @classmethod
-    def setUpClass(cls):
-        # mock the whole SailorConfig for all tests
-        cls.config_mock = patch('sailor.utils.config.SailorConfig')
-        cls.config_mock.start()
+@pytest.fixture(autouse=True, scope='module')
+def mock_config():
+    with patch('sailor.utils.config.SailorConfig') as mock:
+        yield mock
 
-    @classmethod
-    def tearDownClass(cls):
-        cls.config_mock.stop()
 
-    def test_fetch_endpoint_data_url_parameters(self):
-        mock_session = Mock()
-        mock_session.request.return_value = Mock(headers={'Content-Type': 'application/json'})
-        oauth_flow = OAuthFlow('test_service', {})
+def test_fetch_endpoint_data_url_parameters():
+    mock_session = Mock()
+    mock_session.request.return_value = Mock(headers={'Content-Type': 'application/json'})
+    oauth_flow = OAuthFlow('test_service', {})
 
-        current_url = 'https://some-service-url.to/api/resource?hello=world&old=true'
-        parameters = {'old': 'false', 'new': 'true'}
+    current_url = 'https://some-service-url.to/api/resource?hello=world&old=true'
+    parameters = {'old': 'false', 'new': 'true'}
 
-        expected_url = 'https://some-service-url.to/api/resource?hello=world&old=false&new=true&%24format=json'
+    expected_url = 'https://some-service-url.to/api/resource?hello=world&old=false&new=true&%24format=json'
 
-        with patch.object(oauth_flow, '_get_session', return_value=mock_session):
-            oauth_flow.fetch_endpoint_data(current_url, 'GET', parameters)
-        mock_session.request.assert_called_once_with('GET', expected_url)
+    with patch.object(oauth_flow, '_get_session', return_value=mock_session):
+        oauth_flow.fetch_endpoint_data(current_url, 'GET', parameters)
+    mock_session.request.assert_called_once_with('GET', expected_url)
 
-    def test_fetch_endpoint_data(self):
-        expected_data = {'a': 1, 'b': True, 'c': '42'}
 
-        class MockResponse:
-            ok = True
-            headers = {'Content-Type': 'application/json'}
+def test_fetch_endpoint_data():
+    expected_data = {'a': 1, 'b': True, 'c': '42'}
 
-            def json(self):
-                return expected_data
+    class MockResponse:
+        ok = True
+        headers = {'Content-Type': 'application/json'}
 
-        class MockSession:
-            headers = None
+        def json(self):
+            return expected_data
 
-            def request(self, method, endpoint_url):
-                return MockResponse()
+    scope_config = {
+        'test_service': ['scope1', 'scope2', 'scope3']
+    }
 
-        scope_config = {
-            'test_service': ['scope1', 'scope2', 'scope3']
-        }
+    full_scopes = ['foo!scope1', 'bar!scope2', 'foobar!scope3']
+    encoded_token = jwt.encode({'scope': full_scopes}, 'some_secret')
 
-        full_scopes = ['foo!scope1', 'bar!scope2', 'foobar!scope3']
-        encoded_token = jwt.encode({'scope': full_scopes}, 'some_secret')
+    oauth_flow = OAuthFlow('test_service', scope_config)
 
-        oauth_flow = OAuthFlow('test_service', scope_config)
+    with patch.object(oauth_flow, '_get_session') as get_session_mock:
+        get_session_mock.return_value.access_token_response.json.return_value = {'access_token': encoded_token}
+        get_session_mock.return_value.request.return_value = MockResponse()
+        result_data = oauth_flow.fetch_endpoint_data('https://some-service-url.to/api/resource', 'GET')
 
-        with patch.object(oauth_flow, 'get_access_token', return_value=encoded_token) as get_token_mock:
-            with patch.object(oauth_flow, '_get_session', return_value=MockSession()) as get_session_mock:
-                result_data = oauth_flow.fetch_endpoint_data('https://some-service-url.to/api/resource', 'GET')
+    assert expected_data == result_data
+    params = get_session_mock.call_args[0][0]
+    assert params['scope'] == ' '.join(full_scopes), 'Wrong scopes provided to oauth session'
 
-                self.assertEqual(
-                    result_data,
-                    expected_data,
-                    'Invalid result data')
 
-            get_token_mock.assert_called_once()
-            get_session_mock.assert_called_once()
+def test_scopes_config_not_available():
+    scope_config = {}
 
-            method, data = list(get_session_mock.call_args)[0]
+    oauth_flow = OAuthFlow('test_service', scope_config)
+    oauth_flow._resolve_configured_scopes()
+    assert oauth_flow.resolved_scopes == [], "OAuthFlow must not have scopes"
 
-            self.assertEqual(
-                data['scope'],
-                ' '.join(full_scopes),
-                'Wrong scopes provided to oauth session')
 
-    def test_scopes_config_not_available(self):
-        scope_config = {}
+def test_scopes_config_available_token_available():
+    scope_config = {
+        'test_service': ['scope1', 'scope2', 'scope3']
+    }
 
-        oauth_flow = OAuthFlow('test_service', scope_config)
+    encoded_token = jwt.encode({
+        'scope': ['foo!scope1', 'bar!scope2', 'foobar!scope3']
+    }, 'some_secret')
+
+    oauth_flow = OAuthFlow('test_service', scope_config)
+
+    with patch('rauth.OAuth2Service.get_auth_session') as mock_method:
+        mock_method.return_value.access_token_response.json.return_value = {'access_token': encoded_token}
         oauth_flow._resolve_configured_scopes()
-        self.assertEqual(oauth_flow.resolved_scopes, [], "OAuthFlow must not have scopes")
 
-    def test_scopes_config_available_token_available(self):
-        scope_config = {
-            'test_service': ['scope1', 'scope2', 'scope3']
-        }
+    assert oauth_flow.resolved_scopes == ['foo!scope1', 'bar!scope2', 'foobar!scope3'], (
+        "Scopes have been resolved incorrectly")
+    mock_method.assert_called_once()
 
-        encoded_token = jwt.encode({
-            'scope': ['foo!scope1', 'bar!scope2', 'foobar!scope3']
-        }, 'some_secret')
 
-        oauth_flow = OAuthFlow('test_service', scope_config)
+def test_scopes_config_available_getting_token_fails():
+    scope_config = {
+        'test_service': ['scope1', 'scope2', 'scope3']
+    }
 
-        with patch.object(oauth_flow, 'get_access_token', return_value=encoded_token) as mock_method:
+    oauth_flow = OAuthFlow('test_service', scope_config)
+
+    with patch.object(oauth_flow, '_get_session', side_effect=Exception) as mock_method:
+        with pytest.raises(Exception):
             oauth_flow._resolve_configured_scopes()
-            self.assertEqual(oauth_flow.resolved_scopes, ['foo!scope1', 'bar!scope2', 'foobar!scope3'],
-                             "Scopes have been resolved incorrectly")
 
-        mock_method.assert_called_once()
+    assert oauth_flow.resolved_scopes == [], "Scopes must be empty"
+    mock_method.assert_called_once()
 
-    def test_scopes_config_available_getting_token_fails(self):
-        scope_config = {
-            'test_service': ['scope1', 'scope2', 'scope3']
-        }
 
-        oauth_flow = OAuthFlow('test_service', scope_config)
+@patch('jwt.decode', return_value={'scope': []})
+def test_scopes_config_available_decoding_token_fails(jwt_decode_mock):
+    scope_config = {
+        'test_service': ['scope1', 'scope2', 'scope3']
+    }
+    invalid_encoded_token = 'xxxxxxxxxx'  # nosec
+    oauth_flow = OAuthFlow('test_service', scope_config)
 
-        with patch.object(oauth_flow, 'get_access_token', side_effect=Exception) as mock_method:
-            with pytest.raises(Exception):
-                oauth_flow._resolve_configured_scopes()
-            self.assertEqual(oauth_flow.resolved_scopes, [], "Scopes must be empty")
+    with patch('rauth.OAuth2Service.get_auth_session') as mock_method:
+        mock_method.return_value.access_token_response.json.return_value = {'access_token': invalid_encoded_token}
+        with pytest.warns(UserWarning, match=r'Could not resolve all scopes'):
+            oauth_flow._resolve_configured_scopes()
 
-        mock_method.assert_called_once()
-
-    @patch('jwt.decode', return_value={'scope': []})
-    def test_scopes_config_available_decoding_token_fails(self, jwt_decode_mock):
-        scope_config = {
-            'test_service': ['scope1', 'scope2', 'scope3']
-        }
-
-        invalid_encoded_token = 'xxxxxxxxxx'  # nosec
-
-        oauth_flow = OAuthFlow('test_service', scope_config)
-
-        with patch.object(oauth_flow, 'get_access_token', return_value=invalid_encoded_token) as mock_method:
-            with pytest.warns(UserWarning, match=r'Could not resolve all scopes'):
-                oauth_flow._resolve_configured_scopes()
-            self.assertEqual(oauth_flow.resolved_scopes, [], "Scopes must be empty")
-
-        mock_method.assert_called_once()
+    assert oauth_flow.resolved_scopes == [], "Scopes must be empty"
+    mock_method.assert_called_once()


### PR DESCRIPTION
OAuth sessions are used more than once now, removing a lot of redundant calls to obtain a new token.
A new token is created when the session is about to expire or if there is a scope mismatch.
Using sessions inherently reaps the benefits of underlying connection pooling mechanisms.

The OAuth client has been refactored along the way.