### PR TITLE
Refactor OAuthFlow: offer full functionality for requests

### DIFF
--- a/sailor/assetcentral/utils.py
+++ b/sailor/assetcentral/utils.py
@@ -125,15 +125,15 @@ def _compose_queries(unbreakable_filters, breakable_filters):
 def _fetch_data(endpoint_url, unbreakable_filters=(), breakable_filters=()):
     """Retrieve data from the AssetCentral service."""
     filters = _compose_queries(unbreakable_filters, breakable_filters)
-    service = get_oauth_client('asset_central')
+    oauth_client = get_oauth_client('asset_central')
 
     if not filters:
         filters = ['']
 
     result = []
     for filter_string in filters:
-        parameters = {'$filter': filter_string} if filter_string else None
-        endpoint_data = service.fetch_endpoint_data(endpoint_url, method='GET', parameters=parameters)
+        params = {'$filter': filter_string} if filter_string else {}
+        endpoint_data = oauth_client.request('GET', endpoint_url, params=params)
 
         if isinstance(endpoint_data, list):
             result.extend(endpoint_data)

--- a/sailor/assetcentral/utils.py
+++ b/sailor/assetcentral/utils.py
@@ -133,6 +133,7 @@ def _fetch_data(endpoint_url, unbreakable_filters=(), breakable_filters=()):
     result = []
     for filter_string in filters:
         params = {'$filter': filter_string} if filter_string else {}
+        params['$format'] = 'json'
         endpoint_data = oauth_client.request('GET', endpoint_url, params=params)
 
         if isinstance(endpoint_data, list):

--- a/sailor/sap_iot/fetch.py
+++ b/sailor/sap_iot/fetch.py
@@ -47,7 +47,7 @@ def _start_bulk_timeseries_data_export(start_date: str, end_date: str, liot_indi
     base_url = SailorConfig.get('sap_iot', 'export_url')  # todo: figure out what to do about these urls
     request_url = f'{base_url}/v1/InitiateDataExport/{liot_indicator_group}?timerange={start_date}-{end_date}'
 
-    resp = oauth_iot.fetch_endpoint_data(request_url, 'POST')
+    resp = oauth_iot.request('POST', request_url)
     return resp['RequestId']
 
 
@@ -57,7 +57,7 @@ def _check_bulk_timeseries_export_status(export_id: str) -> bool:
     base_url = SailorConfig.get('sap_iot', 'export_url')  # todo: figure out what to do about these urls
     request_url = f'{base_url}/v1/DataExportStatus?requestId={export_id}'
 
-    resp = oauth_iot.fetch_endpoint_data(request_url, 'GET')
+    resp = oauth_iot.request('GET', request_url)
 
     if resp['Status'] == 'The file is available for download.':
         return True
@@ -110,7 +110,7 @@ def _get_exported_bulk_timeseries_data(export_id: str,
     base_url = SailorConfig.get('sap_iot', 'download_url')  # todo: figure out what to do about these urls
     request_url = f"{base_url}/v1/DownloadData('{export_id}')"
 
-    resp = oauth_iot.fetch_endpoint_data(request_url, 'GET')
+    resp = oauth_iot.request('GET', request_url, headers={'Accept': 'application/octet-stream'})
 
     ifile = BytesIO(resp)
     try:

--- a/sailor/utils/oauth_wrapper/OAuthServiceImpl.py
+++ b/sailor/utils/oauth_wrapper/OAuthServiceImpl.py
@@ -69,7 +69,6 @@ class OAuth2Client():
         """
         if method == 'GET':
             parameters = req_kwargs.pop('params', {})
-            parameters.setdefault('$format', 'json')
             url_obj = furl(url)
             url_obj.args = {**url_obj.args, **parameters}
             url = url_obj.tostr(query_quote_plus=False)

--- a/sailor/utils/oauth_wrapper/__init__.py
+++ b/sailor/utils/oauth_wrapper/__init__.py
@@ -1,3 +1,3 @@
-from .OAuthServiceImpl import OAuthFlow  # noqa: F401
+from .OAuthServiceImpl import OAuth2Client  # noqa: F401
 from .OAuthServiceImpl import RequestError  # noqa: F401
 from .clients import get_oauth_client  # noqa: F401

--- a/sailor/utils/oauth_wrapper/clients.py
+++ b/sailor/utils/oauth_wrapper/clients.py
@@ -1,7 +1,7 @@
 """Stores and returns OAuth clients."""
 import logging
 
-from .OAuthServiceImpl import OAuthFlow
+from .OAuthServiceImpl import OAuth2Client
 
 LOG = logging.getLogger(__name__)
 LOG.addHandler(logging.NullHandler())
@@ -9,11 +9,11 @@ LOG.addHandler(logging.NullHandler())
 _clients = {}
 
 
-def get_oauth_client(name) -> OAuthFlow:
+def get_oauth_client(name) -> OAuth2Client:
     """Return an existing OAuth client or create a new one based on the name."""
     if name in _clients:
         return _clients[name]
 
     LOG.debug("Creating new OAuth client for '%s'", name)
-    _clients[name] = OAuthFlow(name)
+    _clients[name] = OAuth2Client(name)
     return _clients[name]

--- a/tests/test_sailor/test_assetcentral/test_utils.py
+++ b/tests/test_sailor/test_assetcentral/test_utils.py
@@ -297,7 +297,7 @@ class TestComposeQueries:
 class TestFetchData:
     @pytest.fixture
     def fetch_mock(self, mock_config):
-        with patch('sailor.utils.oauth_wrapper.OAuthServiceImpl.OAuthFlow.fetch_endpoint_data') as mock:
+        with patch('sailor.utils.oauth_wrapper.OAuthServiceImpl.OAuth2Client.request') as mock:
             yield mock
 
     @pytest.mark.filterwarnings('ignore::sailor.utils.utils.DataNotFoundWarning')
@@ -313,14 +313,14 @@ class TestFetchData:
         assert not issubclass(actual.__class__, str)
         assert isinstance(actual, Iterable)
 
-    def test_no_filters_makes_remote_call_with_no_params(self, fetch_mock):
+    def test_no_filters_makes_remote_call_with_empty_params(self, fetch_mock):
         fetch_mock.return_value = ['result']
         unbreakable_filters = []
         breakable_filters = []
 
         actual = _fetch_data('', unbreakable_filters, breakable_filters)
 
-        fetch_mock.assert_called_once_with('', method='GET', parameters=None)
+        fetch_mock.assert_called_once_with('GET', '', params={})
         assert actual == ['result']
 
     def test_adds_filter_parameter_on_call(self, fetch_mock):
@@ -330,7 +330,7 @@ class TestFetchData:
 
         _fetch_data('', unbreakable_filters, breakable_filters)
 
-        fetch_mock.assert_called_once_with("", method="GET", parameters=expected_parameters)
+        fetch_mock.assert_called_once_with('GET', '', params=expected_parameters)
 
     def test_multiple_calls_aggregated_result(self, fetch_mock):
         unbreakable_filters = ["location eq 'Walldorf'"]

--- a/tests/test_sailor/test_assetcentral/test_utils.py
+++ b/tests/test_sailor/test_assetcentral/test_utils.py
@@ -313,20 +313,22 @@ class TestFetchData:
         assert not issubclass(actual.__class__, str)
         assert isinstance(actual, Iterable)
 
-    def test_no_filters_makes_remote_call_with_empty_params(self, fetch_mock):
+    def test_no_filters_makes_remote_call_without_query_params(self, fetch_mock):
         fetch_mock.return_value = ['result']
         unbreakable_filters = []
         breakable_filters = []
+        expected_params = {'$format': 'json'}
 
         actual = _fetch_data('', unbreakable_filters, breakable_filters)
 
-        fetch_mock.assert_called_once_with('GET', '', params={})
+        fetch_mock.assert_called_once_with('GET', '', params=expected_params)
         assert actual == ['result']
 
     def test_adds_filter_parameter_on_call(self, fetch_mock):
         unbreakable_filters = ["location eq 'Walldorf'"]
         breakable_filters = [["manufacturer eq 'abcCorp'"]]
-        expected_parameters = {'$filter': "location eq 'Walldorf' and (manufacturer eq 'abcCorp')"}
+        expected_parameters = {'$filter': "location eq 'Walldorf' and (manufacturer eq 'abcCorp')",
+                               '$format': 'json'}
 
         _fetch_data('', unbreakable_filters, breakable_filters)
 

--- a/tests/test_sailor/test_utils/test_oauth_flow.py
+++ b/tests/test_sailor/test_utils/test_oauth_flow.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 
-from unittest.mock import patch, Mock, MagicMock
+from unittest.mock import patch, MagicMock
 from datetime import datetime
 
+from rauth import OAuth2Session
 import jwt
 import pytest
 
-from sailor.utils.oauth_wrapper.OAuthServiceImpl import OAuthFlow
+from sailor.utils.oauth_wrapper.OAuthServiceImpl import OAuth2Client, RequestError
 
 
 @pytest.fixture(autouse=True, scope='module')
@@ -15,55 +16,48 @@ def mock_config():
         yield mock
 
 
-def test_fetch_endpoint_data_url_parameters():
-    mock_session = Mock()
-    mock_session.request.return_value = Mock(headers={'Content-Type': 'application/json'})
-    oauth_flow = OAuthFlow('test_service', {})
+@pytest.mark.parametrize('method,expected_url', [
+    ('GET', 'http://testurl.com?%24format=json'),
+    ('POST', 'http://testurl.com')])
+def test_request_sets_json_by_default(method, expected_url):
+    oauth_client = OAuth2Client('test_client')
+    session_mock = MagicMock(OAuth2Session)
 
+    with patch.object(oauth_client, 'get_session', return_value=session_mock):
+        oauth_client.request(method, 'http://testurl.com')
+
+    session_mock.request.assert_called_once_with(method, expected_url, headers={'Accept': 'application/json'})
+
+
+def test_request_converts_params_to_odata_url_on_get():
+    oauth_client = OAuth2Client('test_client')
+    session_mock = MagicMock(OAuth2Session)
     current_url = 'https://some-service-url.to/api/resource?hello=world&old=true'
-    parameters = {'old': 'false', 'new': 'true'}
-
+    params = {'old': 'false', 'new': 'true', '$format': 'json'}
     expected_url = 'https://some-service-url.to/api/resource?hello=world&old=false&new=true&%24format=json'
 
-    with patch.object(oauth_flow, '_get_session', return_value=mock_session):
-        oauth_flow.fetch_endpoint_data(current_url, 'GET', parameters)
-    mock_session.request.assert_called_once_with('GET', expected_url)
+    with patch.object(oauth_client, 'get_session', return_value=session_mock):
+        oauth_client.request('GET', current_url, params=params)
+
+    session_mock.request.assert_called_once_with('GET', expected_url, headers={'Accept': 'application/json'})
 
 
-def test_fetch_endpoint_data():
-    expected_data = {'a': 1, 'b': True, 'c': '42'}
+def test_request_raises_error_when_response_not_ok():
+    mock_response = MagicMock()
+    mock_response.ok = False
+    session_mock = MagicMock(OAuth2Session)
+    session_mock.request.return_value = mock_response
+    oauth_client = OAuth2Client('test_service')
 
-    class MockResponse:
-        ok = True
-        headers = {'Content-Type': 'application/json'}
-
-        def json(self):
-            return expected_data
-
-    scope_config = {
-        'test_service': ['scope1', 'scope2', 'scope3']
-    }
-
-    full_scopes = ['foo!scope1', 'bar!scope2', 'foobar!scope3']
-    encoded_token = jwt.encode({'scope': full_scopes}, 'some_secret')
-
-    oauth_flow = OAuthFlow('test_service', scope_config)
-
-    with patch.object(oauth_flow, '_get_session') as get_session_mock:
-        get_session_mock.return_value.access_token_response.json.return_value = {'access_token': encoded_token}
-        get_session_mock.return_value.request.return_value = MockResponse()
-        result_data = oauth_flow.fetch_endpoint_data('https://some-service-url.to/api/resource', 'GET')
-
-    assert expected_data == result_data
-    assert 'scope' in get_session_mock.call_args[-1]
-    actual_scope = get_session_mock.call_args[-1]['scope']
-    assert actual_scope == ' '.join(full_scopes), 'Wrong scopes provided to oauth session'
+    with patch.object(oauth_client, 'get_session', return_value=session_mock):
+        with pytest.raises(RequestError):
+            oauth_client.request('GET', 'some_url')
 
 
 def test_scopes_config_not_available():
     scope_config = {}
 
-    oauth_flow = OAuthFlow('test_service', scope_config)
+    oauth_flow = OAuth2Client('test_service', scope_config)
     oauth_flow._resolve_configured_scopes()
     assert oauth_flow.resolved_scopes == [], 'OAuthFlow must not have scopes'
 
@@ -77,7 +71,7 @@ def test_scopes_config_available_token_available():
         'scope': ['foo!scope1', 'bar!scope2', 'foobar!scope3']
     }, 'some_secret')
 
-    oauth_flow = OAuthFlow('test_service', scope_config)
+    oauth_flow = OAuth2Client('test_service', scope_config)
 
     with patch('rauth.OAuth2Service.get_auth_session') as mock_method:
         mock_method.return_value.access_token_response.json.return_value = {'access_token': encoded_token}
@@ -93,7 +87,7 @@ def test_scopes_config_available_getting_token_fails():
         'test_service': ['scope1', 'scope2', 'scope3']
     }
 
-    oauth_flow = OAuthFlow('test_service', scope_config)
+    oauth_flow = OAuth2Client('test_service', scope_config)
 
     with patch.object(oauth_flow, '_get_session', side_effect=Exception) as mock_method:
         with pytest.raises(Exception):
@@ -109,7 +103,7 @@ def test_scopes_config_available_decoding_token_fails(jwt_decode_mock):
         'test_service': ['scope1', 'scope2', 'scope3']
     }
     invalid_encoded_token = 'xxxxxxxxxx'  # nosec
-    oauth_flow = OAuthFlow('test_service', scope_config)
+    oauth_flow = OAuth2Client('test_service', scope_config)
 
     with patch('rauth.OAuth2Service.get_auth_session') as mock_method:
         mock_method.return_value.access_token_response.json.return_value = {'access_token': invalid_encoded_token}
@@ -125,7 +119,7 @@ def test_scopes_config_available_decoding_token_fails(jwt_decode_mock):
 def test_get_session_returns_active_session_on_repeated_calls(get_auth_mock, decode_mock):
     expected_session = MagicMock()
     get_auth_mock.return_value = expected_session
-    oauth_flow = OAuthFlow('test_service')
+    oauth_flow = OAuth2Client('test_service')
 
     oauth_flow._get_session()
     actual = oauth_flow._get_session()
@@ -141,7 +135,7 @@ def test_get_session_returns_new_session_if_scopes_are_different(get_auth_mock, 
     new_scopes_requested = 'abc def'
     expected_session = MagicMock()
     get_auth_mock.return_value = expected_session
-    oauth_flow = OAuthFlow('test_service')
+    oauth_flow = OAuth2Client('test_service')
     oauth_flow._active_session = MagicMock()
 
     actual = oauth_flow._get_session(scope=new_scopes_requested)
@@ -156,7 +150,7 @@ def test_get_session_returns_new_session_if_scopes_are_different(get_auth_mock, 
 def test_get_session_returns_new_session_if_about_to_expire(get_auth_mock, decode_mock, time_mock):
     expected_session = MagicMock()
     get_auth_mock.return_value = expected_session
-    oauth_flow = OAuthFlow('test_service')
+    oauth_flow = OAuth2Client('test_service')
     oauth_flow._active_session = MagicMock()
 
     actual = oauth_flow._get_session()

--- a/tests/test_sailor/test_utils/test_oauth_flow.py
+++ b/tests/test_sailor/test_utils/test_oauth_flow.py
@@ -23,7 +23,7 @@ def test_request_sets_json_by_default(method, expected_url):
     oauth_client = OAuth2Client('test_client')
     session_mock = MagicMock(OAuth2Session)
 
-    with patch.object(oauth_client, 'get_session', return_value=session_mock):
+    with patch.object(oauth_client, '_get_session', return_value=session_mock):
         oauth_client.request(method, 'http://testurl.com')
 
     session_mock.request.assert_called_once_with(method, expected_url, headers={'Accept': 'application/json'})
@@ -36,7 +36,7 @@ def test_request_converts_params_to_odata_url_on_get():
     params = {'old': 'false', 'new': 'true', '$format': 'json'}
     expected_url = 'https://some-service-url.to/api/resource?hello=world&old=false&new=true&%24format=json'
 
-    with patch.object(oauth_client, 'get_session', return_value=session_mock):
+    with patch.object(oauth_client, '_get_session', return_value=session_mock):
         oauth_client.request('GET', current_url, params=params)
 
     session_mock.request.assert_called_once_with('GET', expected_url, headers={'Accept': 'application/json'})
@@ -49,7 +49,7 @@ def test_request_raises_error_when_response_not_ok():
     session_mock.request.return_value = mock_response
     oauth_client = OAuth2Client('test_service')
 
-    with patch.object(oauth_client, 'get_session', return_value=session_mock):
+    with patch.object(oauth_client, '_get_session', return_value=session_mock):
         with pytest.raises(RequestError):
             oauth_client.request('GET', 'some_url')
 

--- a/tests/test_sailor/test_utils/test_oauth_flow.py
+++ b/tests/test_sailor/test_utils/test_oauth_flow.py
@@ -16,17 +16,29 @@ def mock_config():
         yield mock
 
 
-@pytest.mark.parametrize('method,expected_url', [
-    ('GET', 'http://testurl.com?%24format=json'),
-    ('POST', 'http://testurl.com')])
-def test_request_sets_json_by_default(method, expected_url):
+def test_request_sets_json_by_default():
     oauth_client = OAuth2Client('test_client')
     session_mock = MagicMock(OAuth2Session)
 
     with patch.object(oauth_client, '_get_session', return_value=session_mock):
-        oauth_client.request(method, 'http://testurl.com')
+        oauth_client.request('METHOD', 'http://testurl.com')
 
-    session_mock.request.assert_called_once_with(method, expected_url, headers={'Accept': 'application/json'})
+    session_mock.request.assert_called_once_with('METHOD', 'http://testurl.com', headers={'Accept': 'application/json'})
+
+
+@pytest.mark.parametrize('headers,expected_headers', [
+    (None, None),
+    ({}, {}),
+    ({'Accept': 'application/octet-stream'}, {'Accept': 'application/octet-stream'}),
+    ({'some-header': 'value'}, {'some-header': 'value'})])
+def test_request_does_not_modify_headers_if_specified(headers, expected_headers):
+    oauth_client = OAuth2Client('test_client')
+    session_mock = MagicMock(OAuth2Session)
+
+    with patch.object(oauth_client, '_get_session', return_value=session_mock):
+        oauth_client.request('METHOD', 'http://testurl.com', headers=headers)
+
+    session_mock.request.assert_called_once_with('METHOD', 'http://testurl.com', headers=expected_headers)
 
 
 def test_request_converts_params_to_odata_url_on_get():


### PR DESCRIPTION
OAuthFlow is only really made for GET requests currently.
This change makes it possible to use the whole functionality that the underlying request method of the requests package offers.