### PR TITLE
Fix OAuth2Client http response handling of request method

### DIFF
--- a/sailor/utils/oauth_wrapper/OAuthServiceImpl.py
+++ b/sailor/utils/oauth_wrapper/OAuthServiceImpl.py
@@ -51,12 +51,16 @@ class OAuth2Client():
     def request(self, method, url, **req_kwargs):
         """Make a request using this convenience wrapper.
 
-        The interface is the same as the :meth:`~requests.sessions.Session.requests` method provides.
-        Adds OData param url formatting for GET requests.
-        If headers are not set, requests for JSON content by default.
+        The interface is the same as the :meth:`requests.sessions.Session.request` method provides but changes the
+        following behavior:
 
-        Will use the currently attached session with this client or create a new one. If scopes are configured with
-        this client, will try to resolve the scopes with the auth server first before making the request.
+        - Does not return a response object. Instead, returns content or raises an error (see below).
+        - Automatically converts supplied 'params' for GET requests to OData URL parameters.
+        - If headers are not set, requests for JSON content by default.
+
+        Client session management: will use the currently attached session with this client or create a new one.
+        If scopes are configured with this client and are not resolved yet, will try to resolve the scopes with
+        the auth server first before making the request.
 
         Returns
         -------

--- a/sailor/utils/oauth_wrapper/OAuthServiceImpl.py
+++ b/sailor/utils/oauth_wrapper/OAuthServiceImpl.py
@@ -88,7 +88,8 @@ class OAuth2Client():
         LOG.debug('Calling %s', url)
         response = session.request(method, url, **req_kwargs)
         if response.ok:
-            if response.headers['Content-Type'] == 'application/json':
+            r_headers = {k.lower(): v for (k, v) in response.headers.items()}
+            if r_headers.get('content-type', '').lower() == 'application/json':
                 return response.json()
             else:
                 return response.content

--- a/sailor/utils/oauth_wrapper/OAuthServiceImpl.py
+++ b/sailor/utils/oauth_wrapper/OAuthServiceImpl.py
@@ -92,8 +92,7 @@ class OAuth2Client():
         LOG.debug('Calling %s', url)
         response = session.request(method, url, **req_kwargs)
         if response.ok:
-            r_headers = {k.lower(): v for (k, v) in response.headers.items()}
-            if r_headers.get('content-type', '').lower() == 'application/json':
+            if response.headers.get('content-type', '').lower() == 'application/json':
                 return response.json()
             else:
                 return response.content

--- a/tests/test_sailor/test_utils/test_oauth_flow.py
+++ b/tests/test_sailor/test_utils/test_oauth_flow.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from rauth import OAuth2Session
 import jwt
 import pytest
+from requests.models import Response
 
 from sailor.utils.oauth_wrapper.OAuthServiceImpl import OAuth2Client, RequestError
 
@@ -72,9 +73,9 @@ def test_request_raises_error_when_response_not_ok():
     ('CoNTenT-tyPE', 'AppLICation/JsOn', True, {'some': 'value'}),
 ])
 def test_request_correctly_checks_content_type_response_header(name, value, json_expected, expected_content):
-    mock_response = MagicMock()
+    mock_response = MagicMock(wraps=Response())
     mock_response.ok = True
-    mock_response.headers = {name: value}
+    mock_response.headers.update({name: value})  # requests lib is using a special case-insensitive dict
     if json_expected:
         mock_response.json.return_value = expected_content
     else:


### PR DESCRIPTION
Field names can be missing entirely.
Field names are also case-insensitive.
Field values can be case-sensitive depending on the field.
In particular the Content-Type field values are case-insensitive.