### PR TITLE
expose content returned by token fetch

### DIFF
--- a/sailor/utils/oauth_wrapper/OAuthServiceImpl.py
+++ b/sailor/utils/oauth_wrapper/OAuthServiceImpl.py
@@ -136,6 +136,7 @@ class OAuth2Client():
         try:
             self._active_session = service.get_auth_session('POST', data=params, decoder=json.loads)
         except json.JSONDecodeError as exception:
+            LOG.debug('Decoding JSON while getting auth session failed.', exc_info=exception)
             raise RuntimeError('Decoding JSON while getting auth session failed. Original content: \n' + exception.doc)
 
         # the get_auth_session method of rauth does not check whether the response was 200 or not

--- a/sailor/utils/oauth_wrapper/OAuthServiceImpl.py
+++ b/sailor/utils/oauth_wrapper/OAuthServiceImpl.py
@@ -132,7 +132,13 @@ class OAuth2Client():
         params = {'grant_type': 'client_credentials', 'scope': scope}
         service = OAuth2Service(name=self.name, client_id=self.client_id, client_secret=self.client_secret,
                                 access_token_url=self.oauth_url)
-        self._active_session = service.get_auth_session('POST', data=params, decoder=json.loads)
+
+        def safe_json_decoder(json_string):
+            try:
+                return json.loads(json_string)
+            except json.JSONDecodeError:
+                raise RuntimeError(json_string)
+        self._active_session = service.get_auth_session('POST', data=params, decoder=safe_json_decoder)
 
         # the get_auth_session method of rauth does not check whether the response was 200 or not
         # and therefore does not log a proper error message

--- a/sailor/utils/oauth_wrapper/OAuthServiceImpl.py
+++ b/sailor/utils/oauth_wrapper/OAuthServiceImpl.py
@@ -133,12 +133,10 @@ class OAuth2Client():
         service = OAuth2Service(name=self.name, client_id=self.client_id, client_secret=self.client_secret,
                                 access_token_url=self.oauth_url)
 
-        def safe_json_decoder(json_string):
-            try:
-                return json.loads(json_string)
-            except json.JSONDecodeError:
-                raise RuntimeError(json_string)
-        self._active_session = service.get_auth_session('POST', data=params, decoder=safe_json_decoder)
+        try:
+            self._active_session = service.get_auth_session('POST', data=params, decoder=json.loads)
+        except json.JSONDecodeError as exception:
+            raise RuntimeError('Decoding JSON while getting auth session failed. Original content: \n' + exception.doc)
 
         # the get_auth_session method of rauth does not check whether the response was 200 or not
         # and therefore does not log a proper error message

--- a/tests/test_sailor/test_utils/test_oauth_flow.py
+++ b/tests/test_sailor/test_utils/test_oauth_flow.py
@@ -117,6 +117,15 @@ def test_scopes_config_available_token_available():
     mock_method.assert_called_once()
 
 
+def test_get_auth_service_non_json_response_raises():
+    oauth_flow = OAuth2Client('test_service')
+
+    with patch('rauth.OAuth2Service.get_raw_access_token') as mock_method:
+        mock_method.return_value.content = 'non-json content'
+        with pytest.raises(RuntimeError, match='non-json content'):
+            oauth_flow._get_session()
+
+
 def test_scopes_config_available_getting_token_fails():
     scope_config = {
         'test_service': ['scope1', 'scope2', 'scope3']


### PR DESCRIPTION
If there is an error when fetching the token, the content is often non-json.
In that case the json-parser swallows the actual error, and just raises a JSONDecodeError.
However, it is useful for the user to see the actual message, hence we're exposing it through a RuntimeError now.