### PR TITLE
Docs: add new apidoc pages automatically

### DIFF
--- a/.ci/docs/Jenkinsfile
+++ b/.ci/docs/Jenkinsfile
@@ -34,7 +34,10 @@ pipeline {
             }
             steps {
                 sh 'git config --global credential.helper "!f() { echo username=\$GIT_CREDENTIALS_USR; echo password=\$GIT_CREDENTIALS_PSW; }; f"'
+                sh '''git config --global user.name "${GIT_CONFIG_USER_NAME};"
+                      git config --global user.email "${GIT_CONFIG_USER_MAIL}"'''
                 dir("MAIN") {
+                    sh './.ci/docs/add_apidoc_main.sh $DOCS_SOURCE_DIR'
                     sh './.ci/docs/publish_docs.sh $DOCS_SOURCE_DIR'
                 }
             }

--- a/.ci/docs/add_apidoc_main.sh
+++ b/.ci/docs/add_apidoc_main.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -e
+
+docs_dir=$1
+
+trigger_commit=$(git rev-parse --short HEAD)
+
+git add "${docs_dir}"/apidoc
+if git commit -m "[CI] Updated apidoc rst files (ref: ${trigger_commit})."; then
+    git push origin HEAD:main
+fi

--- a/.ci/docs/build_docs.sh
+++ b/.ci/docs/build_docs.sh
@@ -3,6 +3,9 @@
 docs_dir=$1
 
 cd "${docs_dir}"
+make apidoc
 make html
+# due to weird sphinx behaviour we need to "change" the apidoc and re-make the docs otherwise the
+# API doc menu on the left side will not be present when viewing an API doc page
 touch apidoc.rst
 make html SPHINXOPTS="-a"

--- a/.ci/docs/publish_docs.sh
+++ b/.ci/docs/publish_docs.sh
@@ -4,14 +4,12 @@ docs_dir=$1
 
 trigger_commit=$(git rev-parse --short HEAD)
 
-git config --global user.name "${GIT_CONFIG_USER_NAME}"
-git config --global user.email "${GIT_CONFIG_USER_MAIL}"
-
 git clone --branch gh-pages "${GIT_URL}" ../DOCS
 rm -rf ../DOCS/*
 cp -r "${docs_dir}"/_build/* ../DOCS
-cd ../DOCS
+pushd ../DOCS
 git add .
 if git commit -m "[CI] Updated documentation (ref: ${trigger_commit})."; then
     git push origin gh-pages
 fi
+popd


### PR DESCRIPTION
When adding a new python module the apidoc page for this module is now generated automatically.
Deleting apidoc rst pages to account for removed python modules must still be done manually.

### Note (not directly related to this change, but still FYI)
All apidoc documentation html pages can be found in the module index (as usually).
For the navigation pane on the left, we only list assetcentral and sap_iot modules, therefore one
still needs to add new sailor packages to be listed (when necessary).

### Tested
Jenkins ✅ 