### PR TITLE
Code quality: add SonarCloud to validation jobs

### DIFF
--- a/.ci/pydocstyle_wrapper.py
+++ b/.ci/pydocstyle_wrapper.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+"""Wrapper script for pydocstyle that is used generate a custom report for SonarCloud."""
+# this file was modified from the original pydocstyle cli.py
+
+import sys
+import json
+
+from pydocstyle import check
+from pydocstyle.config import ConfigurationParser, IllegalConfiguration
+
+
+conf = ConfigurationParser()
+
+
+try:
+    conf.parse()
+except IllegalConfiguration:
+    sys.exit(2)
+
+errors = []
+try:
+    for (filename, checked_codes, ignore_decorators) in conf.get_files_to_check():
+        errors.extend(
+            check(
+                (filename,),
+                select=checked_codes,
+                ignore_decorators=ignore_decorators,
+            )
+        )
+except IllegalConfiguration as error:
+    sys.stderr.write(error.args[0])
+    sys.exit(2)
+
+
+sonar_issues = []
+
+for error in errors:
+    if hasattr(error, 'code'):
+        sonar_issues.append(
+            {
+                "engineId": "pydocstyle",
+                "ruleId": error.code,
+                "severity": "MINOR",
+                "type": "CODE_SMELL",
+                "primaryLocation": {
+                    "message": error.message,
+                    "filePath": error.filename,
+                    "textRange": {
+                        "startLine": error.line,
+                        "startColumn": 1,
+                    }
+                },
+                "effortMinutes": 5,
+            }
+        )
+
+exit_code = 0
+if len(errors) > 0:
+    exit_code = 1
+
+json.dump({"issues": sonar_issues}, sys.stdout)
+sys.exit(exit_code)

--- a/.ci/requirements_dev.txt
+++ b/.ci/requirements_dev.txt
@@ -1,3 +1,4 @@
--r requirements_pr.txt
+-r requirements_lint.txt
+-r requirements_test.txt
 -r docs/requirements_docs.txt
 -r release/requirements_release.txt

--- a/.ci/requirements_lint.txt
+++ b/.ci/requirements_lint.txt
@@ -1,7 +1,3 @@
-# testing
-pytest
-
-# linting
 flake8
 pep8-naming
 flake8-import-order

--- a/.ci/requirements_test.txt
+++ b/.ci/requirements_test.txt
@@ -1,0 +1,2 @@
+pytest
+coverage

--- a/.ci/run_lint.sh
+++ b/.ci/run_lint.sh
@@ -1,7 +1,13 @@
-#!/bin/sh -e
+#!/bin/bash -e
 
 linter=$1
 args=$2
+
+# open new descriptor(3) and make it the only one descriptor to write to stdout. point regular stdout to stderr.
+# => only the linting program will write to stdout when we point its output to descriptor(3), everything else goes to stderr.
+# => now you can do "./run_lint.sh pydocstyle > pydocstyle.out" and get only the linter output.
+exec 3>&1
+exec 1>&2
 
 GIT_REMOTE="$(git remote show | head -n 1)"
 GIT_MASTER_COMMIT=$(git log -n 1 --pretty=format:"%H" "${GIT_REMOTE}"/main)
@@ -9,15 +15,16 @@ GIT_LAST_COMMIT=$(git rev-parse HEAD)
 
 file_filter='\.py$'
 # exclude tests directory when linting with pydocstyle
-if [ "${linter}" = "pydocstyle" ]; then
+if [[ "${linter}" == *pydocstyle* ]]; then
   file_filter='^(?!tests/).*\.py$'
 fi
 pyfiles=$(git --no-pager diff --diff-filter=ACMRTUXB --name-only "${GIT_MASTER_COMMIT}" "${GIT_LAST_COMMIT}" | grep -P "${file_filter}" | tr '\n' ' ') || true
 
 ret_code=0
-if [ -n "${pyfiles}" ]; then
+if [[ -n "${pyfiles}" ]]; then
+  # write the run-command to descriptor(3) which was set up to write to stdout
   run_command="${linter} ${args} ${pyfiles}"
-  eval "${run_command}" || ret_code=1
+  eval "${run_command}" >&3 || ret_code=1
 else
   echo 'No py file changes detected. Skipping linting.'
 fi

--- a/.github/workflows/main_validation.yml
+++ b/.github/workflows/main_validation.yml
@@ -20,8 +20,42 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install pytest
+          pip install -r .ci/requirements_test.txt
           pip install -r requirements.txt
 
       - name: Run pytest
-        run: pytest
+        run: |
+          coverage run -m pytest -q tests
+          coverage xml
+
+      - name: Store coverage for sonar job
+        uses: actions/upload-artifact@v1
+        with:
+          name: coverage
+          path: coverage.xml
+
+  sonarcloud:
+    name: SonarCloud
+    runs-on: ubuntu-latest
+    if: always()
+    needs: pytest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Get coverage from pytest job
+        uses: actions/download-artifact@v1
+        with:
+          name: coverage
+        continue-on-error: true
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+          args: >
+            -Dsonar.python.coverage.reportPaths=coverage/coverage.xml
+

--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -16,11 +16,19 @@ jobs:
 
       - name: prepare
         run: |
+          pip install -r .ci/requirements_test.txt
           pip install -r requirements.txt
-          pip install pytest
 
       - name: pytest
-        run: pytest -q tests
+        run: |
+          coverage run -m pytest -q tests
+          coverage xml
+
+      - name: Store coverage for sonar job
+        uses: actions/upload-artifact@v1
+        with:
+          name: coverage
+          path: coverage.xml
 
 
   Linting:
@@ -34,12 +42,65 @@ jobs:
 
       - name: prepare
         run: | 
-          pip install -r .ci/requirements_pr.txt
+          pip install -r .ci/requirements_lint.txt
           git fetch --depth 1 origin main
+          mkdir ../reports
 
-      - name: bandit
-        run: ./.ci/run_lint.sh bandit "--silent --ini setup.cfg"
-      - name: flake8
-        run: ./.ci/run_lint.sh flake8
-      - name: pydocstyle
-        run: ./.ci/run_lint.sh pydocstyle
+      - name: Lint (bandit)
+        run: |
+          ./.ci/run_lint.sh bandit "--ini setup.cfg --output ../reports/bandit.json -f json" || true
+          ./.ci/run_lint.sh bandit "--ini setup.cfg --silent"
+      - name: Lint (flake8)
+        if: always()
+        run: |
+          ./.ci/run_lint.sh flake8 "--output-file=../reports/flake8.out" || true
+          ./.ci/run_lint.sh flake8
+      - name: Lint (pydocstyle)
+        if: always()
+        run: |
+          ./.ci/run_lint.sh ./.ci/pydocstyle_wrapper.py > ../reports/pydocstyle.json || true
+          ./.ci/run_lint.sh pydocstyle
+
+      - name: Store reports for sonar job
+        uses: actions/upload-artifact@v1
+        if: always()
+        with:
+          name: linting-reports
+          path: ../reports/
+
+
+  # the scanner can run independently but if it has reports available on the specified paths of the sonar properties file
+  # it will use them. therefore we wait for the previous jobs to finish, but carry on even if they have failed.
+  Sonarcloud:
+    name: SonarCloud
+    runs-on: ubuntu-latest
+    if: always()
+    needs: [Linting,Tests]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Get coverage report
+        uses: actions/download-artifact@v1
+        with:
+          name: coverage
+        continue-on-error: true
+
+      - name: Get linting reports
+        uses: actions/download-artifact@v1
+        with:
+          name: linting-reports
+        continue-on-error: true
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+          args: >
+            -Dsonar.python.coverage.reportPaths=coverage/coverage.xml
+            -Dsonar.python.flake8.reportPaths=linting-reports/flake8.out
+            -Dsonar.python.bandit.reportPaths=linting-reports/bandit.json
+            -Dsonar.externalIssuesReportPaths=linting-reports/pydocstyle.json

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -31,3 +31,7 @@ License: Apache-2.0
 Files: docs/_templates/apidoc/module.rst_t, docs/_templates/apidoc/package.rst_t
 Copyright:  2007-2021 by the Sphinx team. Modifications 2021 SAP SE or an SAP affiliate company and project "Sailor" contributors
 License: BSD-2-Clause
+
+Files: .ci/pydocstyle_wrapper.py
+Copyright: 2012 GreenSteam. 2014-2020 Amir Rachum. 2020 Sambhav Kothari. Modifications 2021 SAP SE or an SAP affiliate company and project "Sailor" contributors
+License: MIT

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) <year> <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,7 @@
 .. image:: https://api.reuse.software/badge/github.com/SAP/project-sailor
     :target: https://api.reuse.software/info/github.com/SAP/project-sailor
+.. image:: https://sonarcloud.io/api/project_badges/measure?project=SAP_project-sailor&metric=alert_status
+    :target: https://sonarcloud.io/dashboard?id=SAP_project-sailor
 
 ================
 Project "Sailor"

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -69,11 +69,11 @@ This section describes how we support additonal use cases that may occur during 
 
 Dev tools
 ~~~~~~~~~
-Install all tools required for testing and linting by running:
+Install tools required for everything related to Sailor development by running:
 
 .. code-block::
 
-    pip install -r .ci/requirements_ci.txt
+    pip install -r .ci/requirements_dev.txt
 
 Find the current settings and/or possible instructions to run linting/testing tools in ``setup.cfg``.
 
@@ -94,11 +94,11 @@ Building the package
 ~~~~~~~~~~~~~~~~~~~~
 We are using a PEP517 and PEP518 compliant build tooling.
 
-To build the project simply run:
+To create distribution files simply run:
 
 .. code-block::
 
-    python -m build
+    python -m build -ws
 
 
 .. _contributing_documentation:
@@ -111,7 +111,7 @@ and can be found in the :code:`docs` folder.
 
 Requirements
 ------------
-You will need to install Sphinx and dependencies that we use. This can be done via pip:
+You will need to install Sphinx and dependencies that we use. If you have installed all dev tools already, you can skip this step.
 
 .. code-block::
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,3 +23,7 @@ add-ignore = D104,D404
 # 3rd party library patsy causes deprecation warnings.
 filterwarnings = default
     ignore::DeprecationWarning:patsy
+
+
+[coverage:run]
+include=sailor/**

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,5 @@
+sonar.projectKey=SAP_project-sailor
+sonar.organization=sap-1
+
+sonar.sources=sailor
+sonar.tests=tests


### PR DESCRIPTION
- Sonarcloud added to main branch validation (incl. coverage)
- Sonarcloud added to PR validation (incl. coverage and linting)
- Add badge to README
- Reorganizing of requirements files

Sonarcloud will only analyze the sources in "sailor" folder.
Sonarcloud will always run, even if tests or linting failed.
Linting and tests jobs will still fail on its own, i.e., Sonarcloud is considered an additional check tool.