### PR TITLE
adapt the endpoint for the funky non-abstract abstract SAP IoT API

### DIFF
--- a/sailor/sap_iot/write.py
+++ b/sailor/sap_iot/write.py
@@ -29,7 +29,7 @@ def _upload_data_single_equipment(data_subset, equipment_id, tags):
     LOG.debug('Uploading data for equipment %s', equipment_id)
 
     base_url = SailorConfig.get('sap_iot', 'upload_url')
-    request_url = f'{base_url}/Timeseries/extend/Measurements/objectId/{equipment_id}'
+    request_url = f'{base_url}/Timeseries/extend/Measurements/equipmentId/{equipment_id}'
     oauth_iot = get_oauth_client('sap_iot')
 
     # shape[1] is the number of columns, we want to divide the page size by the number of columns as each column

--- a/tests/test_sailor/test_sap_iot/test_write.py
+++ b/tests/test_sailor/test_sap_iot/test_write.py
@@ -78,7 +78,7 @@ def test_each_equipment_one_request(mock_oauth, mock_config, make_indicator_set,
     indicator_set = make_indicator_set(propertyId=['indicator_id_A', 'indicator_id_B'])
     equipment_set = make_equipment_set(equipmentId=['equipment_A', 'equipment_B'])
     dataset = make_dataset(indicator_set, equipment_set)
-    request_base = 'UPLOAD_BASE_URL/Timeseries/extend/Measurements/objectId/'
+    request_base = 'UPLOAD_BASE_URL/Timeseries/extend/Measurements/equipmentId/'
 
     upload_indicator_data(dataset)
     urls = {args[0][1] for args in mock_oauth.call_args_list}


### PR DESCRIPTION
Apparently (I guess) AC/PAI decided on their version of the non-abstract abstract API, and that changes the endpoint URL.
I have no idea how generic this now is...