### PR TITLE
small fix to Notification.plot_overview

### DIFF
--- a/sailor/assetcentral/notification.py
+++ b/sailor/assetcentral/notification.py
@@ -185,6 +185,9 @@ class NotificationSet(ResultSet):
         data = self.as_df(columns=['malfunction_start_date', 'malfunction_end_date',
                                    'equipment_name', 'confirmed_failure_mode_description'])
 
+        # if there are any `NA` values in the equipment_name the plot gets messed up.
+        data = data.dropna(axis=0, subset=['equipment_name'])
+
         aes = {
             'x': 'malfunction_start_date', 'xend': 'malfunction_end_date',
             'y': 'equipment_name', 'yend': 'equipment_name',

--- a/sailor/assetcentral/notification.py
+++ b/sailor/assetcentral/notification.py
@@ -186,7 +186,8 @@ class NotificationSet(ResultSet):
                                    'equipment_name', 'confirmed_failure_mode_description'])
 
         # if there are any `NA` values in the equipment_name the plot gets messed up.
-        data = data.dropna(axis=0, subset=['equipment_name'])
+        # this turns the NAs into an 'nan' string, which works fine.
+        data['equipment_name'] = data['equipment_name'].astype(str)
 
         aes = {
             'x': 'malfunction_start_date', 'xend': 'malfunction_end_date',


### PR DESCRIPTION
plot_overview produces a wrong y-axis (the axis along which the equipment are displayed) if there are any NA values in the equipment_name. This fix turns those NAs into strings (with value 'nan') fixing the plot.