### PR TITLE
Configure In Solidarity app to ignore "masterdata"

### DIFF
--- a/.github/in-solidarity.yml
+++ b/.github/in-solidarity.yml
@@ -1,0 +1,13 @@
+rules:
+  master:
+    level: off
+  masterdata:
+    level: warning
+    regex:
+      - /\b(?!masterdata|masterdata\w+\b)master/gi
+    alternatives:
+      - primary
+      - main
+      - leader
+      - active
+      - writer


### PR DESCRIPTION
The "In Solidarity" app also asks teams to change "masterdata" (not only "master") in favor of more inclusive terms. However, "masterdata" is still considered to be a proper term without having discriminatory aspects. This PR changes the In Solidarity configuration locally for this repository to reflect that. In case that works for you, we can enable this configuration organization-wide.