### PR TITLE
Docs: add inherited functions of classes

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -8,14 +8,13 @@ SPHINXPROJ    = sailor
 SOURCEDIR     = .
 BUILDDIR      = _build
 
-APIDOC_OPTIONS = members,show-inheritance
 APIDOC_TEMPLATEDIR = _templates/apidoc
 APIDOC_OUTDIR = apidoc
 APIDOC_SOURCEDIR = ../sailor
 
 .PHONY: apidoc
 apidoc:
-	@SPHINX_APIDOC_OPTIONS="$(APIDOC_OPTIONS)" sphinx-apidoc -e -f --templatedir "$(APIDOC_TEMPLATEDIR)" -o "$(APIDOC_OUTDIR)" "$(APIDOC_SOURCEDIR)"
+	@SPHINX_APIDOC_OPTIONS="members" sphinx-apidoc -e -f --templatedir "$(APIDOC_TEMPLATEDIR)" -o "$(APIDOC_OUTDIR)" "$(APIDOC_SOURCEDIR)"
 
 .PHONY: Makefile
 html:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,7 +45,6 @@ autodoc_default_options = {
     'member-order': 'groupwise',
     'show-inheritance': True,
     'inherited-members': True,
-    # 'undoc-members': True      # TODO: all properties vs only documented ones, e.g. Equipment.location
 }
 custom_autodoc_skip_classes = [collections.abc.Sequence, BaseException]
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,7 +45,7 @@ autodoc_default_options = {
     'member-order': 'groupwise',
     'show-inheritance': True,
     'inherited-members': True,
-    #'undoc-members': True      # TODO: all properties vs only documented ones, e.g. Equipment.location
+    # 'undoc-members': True      # TODO: all properties vs only documented ones, e.g. Equipment.location
 }
 custom_autodoc_skip_classes = [collections.abc.Sequence, BaseException]
 
@@ -198,8 +198,12 @@ def _skip_helper_get_class_of_method(meth):
             return cls
     return getattr(meth, '__objclass__', None)
 
-# function that skips collections.abc.Sequence method
+
 def skip_classes(classes_to_skip):
+    """Return a function that can be used to skip documentation of specified class members.
+
+    To be used together with the 'autodoc-skip-member' event.
+    """
     def skip_func(app, what, name, obj, skip, options):
         getclass = _skip_helper_get_class_of_method(obj)
         if getclass in classes_to_skip:
@@ -207,5 +211,6 @@ def skip_classes(classes_to_skip):
         return skip
     return skip_func
 
-def setup(app):
+
+def setup(app):  # noqa: D103 (documented by sphinx itself)
     app.connect('autodoc-skip-member', skip_classes(custom_autodoc_skip_classes))

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -115,7 +115,7 @@ html_context = {
   'display_github': True,
   'github_user': 'SAP',
   'github_repo': 'project-sailor',
-  'github_version': 'master/docs/',
+  'github_version': 'main/docs/',
 }
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,6 +19,8 @@
 #
 import os
 import sys
+import inspect
+import collections.abc
 sys.path.insert(0, os.path.abspath('..'))
 
 
@@ -39,7 +41,13 @@ extensions = ['sphinx.ext.autodoc',
               ]
 
 autodoc_typehints = 'description'
-autodoc_member_order = 'groupwise'
+autodoc_default_options = {
+    'member-order': 'groupwise',
+    'show-inheritance': True,
+    'inherited-members': True,
+    #'undoc-members': True      # TODO: all properties vs only documented ones, e.g. Equipment.location
+}
+custom_autodoc_skip_classes = [collections.abc.Sequence, BaseException]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -179,3 +187,25 @@ texinfo_documents = [
      author, 'sailor', 'One line description of project.',
      'Miscellaneous'),
 ]
+
+
+# it's not perfect, but it works for inherited functions in most cases
+def _skip_helper_get_class_of_method(meth):
+    if inspect.isfunction(meth):
+        cls_name = meth.__qualname__.split('.')[0]
+        cls = getattr(inspect.getmodule(meth), cls_name, None)
+        if isinstance(cls, type):
+            return cls
+    return getattr(meth, '__objclass__', None)
+
+# function that skips collections.abc.Sequence method
+def skip_classes(classes_to_skip):
+    def skip_func(app, what, name, obj, skip, options):
+        getclass = _skip_helper_get_class_of_method(obj)
+        if getclass in classes_to_skip:
+            return True
+        return skip
+    return skip_func
+
+def setup(app):
+    app.connect('autodoc-skip-member', skip_classes(custom_autodoc_skip_classes))


### PR DESCRIPTION
We configure Sphinx to add inherited to class apidocs. This allows the user of the documentation to see all functions of a class at a glance.

At the same time it creates the problem that some functions of Python's base classes are documented.
We have a workaround which filters out those inherited functions.