### PR TITLE
Make MasterDataEntity magic functions only work on id property

### DIFF
--- a/sailor/_base/masterdata.py
+++ b/sailor/_base/masterdata.py
@@ -127,8 +127,7 @@ class MasterDataEntity:
 
     def __repr__(self) -> str:
         """Return a very short string representation."""
-        name = getattr(self, 'name', getattr(self, 'short_description', None))
-        return f'"{self.__class__.__name__}(name="{name}", id="{self.id}")'
+        return f'"{self.__class__.__name__}(id="{self.id}")'
 
     def __eq__(self, obj):
         """Compare two objects based on instance type and id."""

--- a/sailor/_base/masterdata.py
+++ b/sailor/_base/masterdata.py
@@ -127,7 +127,7 @@ class MasterDataEntity:
 
     def __repr__(self) -> str:
         """Return a very short string representation."""
-        return f'"{self.__class__.__name__}(id="{self.id}")'
+        return f'{self.__class__.__name__}(id="{self.id}")'
 
     def __eq__(self, obj):
         """Compare two objects based on instance type and id."""

--- a/sailor/assetcentral/utils.py
+++ b/sailor/assetcentral/utils.py
@@ -39,7 +39,10 @@ class _AssetcentralField(_base.MasterDataField):
 class AssetcentralEntity(_base.MasterDataEntity):
     """Common base class for AssetCentral entities."""
 
-    pass
+    def __repr__(self) -> str:
+        """Return a very short string representation."""
+        name = getattr(self, 'name', getattr(self, 'short_description', None))
+        return f'"{self.__class__.__name__}(name="{name}", id="{self.id}")'
 
 
 class AssetcentralEntitySet(_base.MasterDataEntitySet):

--- a/sailor/assetcentral/utils.py
+++ b/sailor/assetcentral/utils.py
@@ -42,7 +42,7 @@ class AssetcentralEntity(_base.MasterDataEntity):
     def __repr__(self) -> str:
         """Return a very short string representation."""
         name = getattr(self, 'name', getattr(self, 'short_description', None))
-        return f'"{self.__class__.__name__}(name="{name}", id="{self.id}")'
+        return f'{self.__class__.__name__}(name="{name}", id="{self.id}")'
 
 
 class AssetcentralEntitySet(_base.MasterDataEntitySet):

--- a/sailor/pai/alert.py
+++ b/sailor/pai/alert.py
@@ -75,6 +75,11 @@ class Alert(PredictiveAssetInsightsEntity):
 
     _field_map = {field.our_name: field for field in _ALERT_FIELDS}
 
+    def __repr__(self) -> str:
+        """Return a very short string representation."""
+        descr = getattr(self, 'description', None)
+        return f'{self.__class__.__name__}(description="{descr}", id="{self.id}")'
+
 
 class AlertSet(PredictiveAssetInsightsEntitySet):
     """Class representing a group of Alerts."""

--- a/sailor/pai/utils.py
+++ b/sailor/pai/utils.py
@@ -28,9 +28,7 @@ class _PredictiveAssetInsightsField(_base.MasterDataField):
 class PredictiveAssetInsightsEntity(_base.MasterDataEntity):
     """Common base class for PAI entities."""
 
-    def __repr__(self) -> str:
-        """Return a very short string representation."""
-        return f'"{self.__class__.__name__}(id="{self.id}")'
+    pass
 
 
 class PredictiveAssetInsightsEntitySet(_base.MasterDataEntitySet):

--- a/tests/test_sailor/test__base/test_masterdata.py
+++ b/tests/test_sailor/test__base/test_masterdata.py
@@ -170,4 +170,3 @@ class TestMasterDataEntitySet:
             assert rs1 == rs2
         else:
             assert rs1 != rs2
-

--- a/tests/test_sailor/test__base/test_masterdata.py
+++ b/tests/test_sailor/test__base/test_masterdata.py
@@ -119,6 +119,22 @@ class TestMasterDataEntity:
 
         assert entity.our_name == 81
 
+    def test_get_available_properties_is_not_empty(self):
+        # note: __subclasses__ requires that all subclasses are imported
+        # currently we ensure this transitively: see __init__.py in test_base
+        abstract_classes = _base.MasterDataEntity.__subclasses__()
+        classes = sum((class_.__subclasses__() for class_ in abstract_classes), start=list())
+        for class_ in classes:
+            actual = class_.get_available_properties()
+            assert actual, f'actual result for {class_.__name__} is empty: {actual}'
+            assert type(actual) == set
+
+    def test_id_in_field_map(self):
+        abstract_classes = _base.MasterDataEntity.__subclasses__()
+        classes = sum((class_.__subclasses__() for class_ in abstract_classes), start=list())
+        for class_ in classes:
+            assert 'id' in class_._field_map
+
 
 class TestMasterDataEntitySet:
     test_classes = sum((class_.__subclasses__() for class_ in _base.MasterDataEntitySet.__subclasses__()), start=[])
@@ -155,13 +171,3 @@ class TestMasterDataEntitySet:
         else:
             assert rs1 != rs2
 
-
-def test_get_available_properties_is_not_empty():
-    # note: __subclasses__ requires that all subclasses are imported
-    # currently we ensure this transitively: see __init__.py in test_base
-    abstract_classes = _base.MasterDataEntity.__subclasses__()
-    classes = sum((class_.__subclasses__() for class_ in abstract_classes), start=list())
-    for class_ in classes:
-        actual = class_.get_available_properties()
-        assert actual, f'actual result for {class_.__name__} is empty: {actual}'
-        assert type(actual) == set

--- a/tests/test_sailor/test__base/test_masterdata.py
+++ b/tests/test_sailor/test__base/test_masterdata.py
@@ -135,6 +135,13 @@ class TestMasterDataEntity:
         for class_ in classes:
             assert 'id' in class_._field_map
 
+    def test_repr_starts_with_classname(self):
+        abstract_classes = _base.MasterDataEntity.__subclasses__()
+        classes = sum((class_.__subclasses__() for class_ in abstract_classes), start=list())
+        for class_ in classes:
+            object_ = class_({'id': 1})
+            assert str(object_).startswith(class_.__name__)
+
 
 class TestMasterDataEntitySet:
     test_classes = sum((class_.__subclasses__() for class_ in _base.MasterDataEntitySet.__subclasses__()), start=[])


### PR DESCRIPTION
# Description

the id property should be the only common denominator for the subclasses to work on.
If subclasses need different behavior, they must overwrite those methods.

Make sure id field is in field map.

# Checklist

Mark "not applicable" if item on the list does not apply to this pull request.

- [x] I have created/adapted unit tests for new code
  - [ ] not applicable 
- [ ] I have added new dependencies as described at the [Contributing](https://sap.github.io/project-sailor/contributing.html#requirements-management) page
  - [x] not applicable 
- [ ] I have made corresponding changes to the documentation (incl. tutorial, etc.)
  - [x] not applicable 
- [ ] I have provided release notes (in description or as comment) if this PR is a new feature OR a change worth mentioning for next release
  - [x] not applicable 
- [ ] I have obtained API approvals if a new SAP API or endpoint is used
  - [x] not applicable 
