### PR TITLE
PAI/AC: Support creating Alerts.

### DIFF
--- a/sailor/_base/masterdata.py
+++ b/sailor/_base/masterdata.py
@@ -1,7 +1,7 @@
 import logging
 from collections import Counter
 from collections.abc import Sequence
-from typing import Union
+from typing import Iterable, Union
 
 import pandas as pd
 import plotnine as p9
@@ -167,7 +167,7 @@ class MasterDataEntitySet(Sequence):
             raise TypeError('Only ResultSets of the same type can be added.')
         return self.__class__(self.elements + other.elements)
 
-    def as_df(self, columns=None):
+    def as_df(self, columns: Iterable[str] = None):
         """Return all information on the objects stored in the MasterDataEntitySet as a pandas dataframe.
 
         ``columns`` can be specified to select the columns (and their order) for the DataFrame.

--- a/sailor/_base/masterdata.py
+++ b/sailor/_base/masterdata.py
@@ -168,7 +168,10 @@ class MasterDataEntitySet(Sequence):
         return self.__class__(self.elements + other.elements)
 
     def as_df(self, columns=None):
-        """Return all information on the objects stored in the MasterDataEntitySet as a pandas dataframe."""
+        """Return all information on the objects stored in the MasterDataEntitySet as a pandas dataframe.
+
+        ``columns`` can be specified to select the columns (and their order) for the DataFrame.
+        """
         if columns is None:
             columns = [field.our_name for field in self._element_type._field_map.values() if field.is_exposed]
         return pd.DataFrame({

--- a/sailor/assetcentral/equipment.py
+++ b/sailor/assetcentral/equipment.py
@@ -11,6 +11,7 @@ from datetime import datetime
 import pandas as pd
 
 from sailor import _base
+from sailor import pai
 from sailor import sap_iot
 from ..utils.timestamps import _string_to_timestamp_parser
 from .constants import VIEW_EQUIPMENT, VIEW_OBJECTS
@@ -243,12 +244,24 @@ class Equipment(AssetcentralEntity):
         --------
         :meth:`sailor.assetcentral.notification.create_notification`
         """
-        args = {'equipment_id': self.id}
+        fixed_kwargs = {'equipment_id': self.id}
         if self.location is not None:
-            args['location_id'] = self.location.id
-        request = _AssetcentralWriteRequest(Notification._field_map, **args)
+            fixed_kwargs['location_id'] = self.location.id
+        request = _AssetcentralWriteRequest(Notification._field_map, **fixed_kwargs)
         request.insert_user_input(kwargs, forbidden_fields=['id', 'equipment_id'])
         return _create_or_update_notification(request, 'POST')
+
+    def create_alert(self, **kwargs) -> pai.alert.Alert:
+        """Create a new alert for this equipment.
+
+        See Also
+        --------
+        :meth:`sailor.pai.alert.create_alert`
+        """
+        fixed_kwargs = {'equipment_id': self.id}
+        request = pai.alert._AlertWriteRequest(**fixed_kwargs)
+        request.insert_user_input(kwargs, forbidden_fields=['id', 'equipment_id'])
+        return pai.alert._create_alert(request)
 
 
 class EquipmentSet(AssetcentralEntitySet):

--- a/sailor/assetcentral/utils.py
+++ b/sailor/assetcentral/utils.py
@@ -84,6 +84,9 @@ class _AssetcentralWriteRequest(UserDict):
         if field := self.field_map.get(key):
             if field.is_writable:
                 field.put_setter(self.data, value)
+            else:
+                warnings.warn(f"Parameter '{key}' is not available for create or update requests and will be ignored.",
+                              stacklevel=5)
         else:
             warnings.warn(f"Unknown name for {type(self).__name__} parameter found: '{key}'.")
             self.data[key] = value

--- a/sailor/pai/__init__.py
+++ b/sailor/pai/__init__.py
@@ -1,4 +1,4 @@
 
-from .alert import find_alerts
+from .alert import find_alerts, create_alert
 
-__all__ = ['find_alerts']
+__all__ = ['find_alerts', 'create_alert']

--- a/sailor/pai/alert.py
+++ b/sailor/pai/alert.py
@@ -5,6 +5,7 @@ Classes are provided for individual Alert as well as groups of Alerts (AlertSet)
 """
 
 from functools import lru_cache
+from typing import Iterable
 import re
 
 import sailor.assetcentral.utils as ac_utils
@@ -96,6 +97,7 @@ class Alert(PredictiveAssetInsightsEntity):
     @property
     @lru_cache(maxsize=None)
     def _custom_properties(self):
+        # the Alerts Extension API supports creating custom fields which must start with Z_ or z_
         return {key: value for key, value in self.raw.items()
                 if key.startswith('Z_') or key.startswith('z_')}
 
@@ -110,7 +112,7 @@ class AlertSet(PredictiveAssetInsightsEntitySet):
         },
     }
 
-    def as_df(self, columns=None, include_all_custom_properties=False):
+    def as_df(self, columns: Iterable[str] = None, include_all_custom_properties=False):
         """Return all information on the objects stored in the AlertSet as a pandas dataframe.
 
         Parameters
@@ -133,7 +135,7 @@ class AlertSet(PredictiveAssetInsightsEntitySet):
             custom_columns = dict.fromkeys(self[0]._custom_properties.keys())
             columns.update(custom_columns)
 
-        return super().as_df(columns=columns)
+        return super().as_df(columns=list(columns))
 
 
 def find_alerts(*, extended_filters=(), **kwargs) -> AlertSet:

--- a/sailor/pai/alert.py
+++ b/sailor/pai/alert.py
@@ -4,7 +4,7 @@ Retrieve Alert information from the alert re-use service.
 Classes are provided for individual Alert as well as groups of Alerts (AlertSet).
 """
 
-from functools import cache
+from functools import lru_cache
 import re
 
 import sailor.assetcentral.utils as ac_utils
@@ -94,7 +94,7 @@ class Alert(PredictiveAssetInsightsEntity):
         return f'{self.__class__.__name__}(description="{descr}", id="{self.id}")'
 
     @property
-    @cache
+    @lru_cache(maxsize=None)
     def _custom_properties(self):
         return {key: value for key, value in self.raw.items()
                 if key.startswith('Z_') or key.startswith('z_')}

--- a/sailor/pai/alert.py
+++ b/sailor/pai/alert.py
@@ -4,16 +4,21 @@ Retrieve Alert information from the alert re-use service.
 Classes are provided for individual Alert as well as groups of Alerts (AlertSet).
 """
 
+from functools import cache
+import re
+
+import sailor.assetcentral.utils as ac_utils
 from sailor import _base
-from ..utils.timestamps import _odata_to_timestamp_parser
-from .._base.masterdata import _qt_odata_datetimeoffset, _qt_double
-from .constants import ALERTS_READ_PATH
+from sailor.utils.oauth_wrapper import get_oauth_client
+from sailor.utils.timestamps import _odata_to_timestamp_parser, _any_to_timestamp, _timestamp_to_isoformat
+from sailor._base.masterdata import _qt_odata_datetimeoffset, _qt_double
+from .constants import ALERTS_READ_PATH, ALERTS_WRITE_PATH
 from .utils import (PredictiveAssetInsightsEntity, _PredictiveAssetInsightsField,
                     PredictiveAssetInsightsEntitySet, _pai_application_url, _pai_fetch_data)
 
 _ALERT_FIELDS = [
-    _PredictiveAssetInsightsField('description', 'Description'),
-    _PredictiveAssetInsightsField('severity_code', 'SeverityCode',
+    _PredictiveAssetInsightsField('description', 'Description', 'description'),
+    _PredictiveAssetInsightsField('severity_code', 'SeverityCode', 'severityCode', is_mandatory=True,
                                   query_transformer=_qt_double),
     _PredictiveAssetInsightsField('category', 'Category'),
     _PredictiveAssetInsightsField('equipment_name', 'EquipmentName'),
@@ -23,20 +28,25 @@ _ALERT_FIELDS = [
     _PredictiveAssetInsightsField('template_name', 'TemplateName'),
     _PredictiveAssetInsightsField('count', 'Count', query_transformer=_qt_double),
     _PredictiveAssetInsightsField('status_code', 'StatusCode', query_transformer=_qt_double),
-    _PredictiveAssetInsightsField('triggered_on', 'TriggeredOn', get_extractor=_odata_to_timestamp_parser(),
+    _PredictiveAssetInsightsField('triggered_on', 'TriggeredOn', 'triggeredOn', is_mandatory=True,
+                                  get_extractor=_odata_to_timestamp_parser(),
+                                  put_setter=lambda p, v: p.update({'triggeredOn': _timestamp_to_isoformat(
+                                                                    _any_to_timestamp(v), with_zulu=True)}),
                                   query_transformer=_qt_odata_datetimeoffset),
     _PredictiveAssetInsightsField('last_occured_on', 'LastOccuredOn', get_extractor=_odata_to_timestamp_parser(),
                                   query_transformer=_qt_odata_datetimeoffset),
     _PredictiveAssetInsightsField('type_description', 'AlertTypeDescription'),
     _PredictiveAssetInsightsField('error_code_description', 'ErrorCodeDescription'),
-    _PredictiveAssetInsightsField('type', 'AlertType'),
+    _PredictiveAssetInsightsField('type', 'AlertType', 'alertType', is_mandatory=True),
+    _PredictiveAssetInsightsField('source', 'Source', 'source'),
     _PredictiveAssetInsightsField('id', 'AlertId'),
-    _PredictiveAssetInsightsField('equipment_id', 'EquipmentID'),
+    _PredictiveAssetInsightsField('equipment_id', 'EquipmentID', 'equipmentId', is_mandatory=True),
     _PredictiveAssetInsightsField('model_id', 'ModelID'),
-    _PredictiveAssetInsightsField('template_id', 'TemplateID'),
-    _PredictiveAssetInsightsField('indicator_id', 'IndicatorID'),
-    _PredictiveAssetInsightsField('indicator_group_id', 'IndicatorGroupID'),
+    _PredictiveAssetInsightsField('template_id', 'TemplateID', 'templateId'),
+    _PredictiveAssetInsightsField('indicator_id', 'IndicatorID', 'indicatorId'),
+    _PredictiveAssetInsightsField('indicator_group_id', 'IndicatorGroupID', 'indicatorGroupId'),
     _PredictiveAssetInsightsField('notification_id', 'NotificationId'),
+    _PredictiveAssetInsightsField('error_code_id', 'ErrorCodeID', 'errorCodeId'),
     _PredictiveAssetInsightsField('_indicator_description', 'IndicatorDescription'),
     _PredictiveAssetInsightsField('_country_id', 'CountryID'),
     _PredictiveAssetInsightsField('_functional_location_id', 'FunctionalLocationID'),
@@ -54,9 +64,7 @@ _ALERT_FIELDS = [
     _PredictiveAssetInsightsField('_processor', 'Processor'),
     _PredictiveAssetInsightsField('_top_equipment_id', 'TopEquipmentID'),
     _PredictiveAssetInsightsField('_planning_plant', 'PlanningPlant'),
-    _PredictiveAssetInsightsField('_error_code_id', 'ErrorCodeID'),
     _PredictiveAssetInsightsField('_operator_id', 'OperatorID'),
-    _PredictiveAssetInsightsField('_source', 'Source'),
     _PredictiveAssetInsightsField('_top_equipment_name', 'TopEquipmentName'),
     _PredictiveAssetInsightsField('_created_on', 'CreatedOn', get_extractor=_odata_to_timestamp_parser(),
                                   query_transformer=_qt_odata_datetimeoffset),
@@ -75,10 +83,21 @@ class Alert(PredictiveAssetInsightsEntity):
 
     _field_map = {field.our_name: field for field in _ALERT_FIELDS}
 
+    def __init__(self, ac_json: dict):
+        super().__init__(ac_json)
+        for key, value in self._custom_properties.items():
+            setattr(self, key, value)
+
     def __repr__(self) -> str:
         """Return a very short string representation."""
         descr = getattr(self, 'description', None)
         return f'{self.__class__.__name__}(description="{descr}", id="{self.id}")'
+
+    @property
+    @cache
+    def _custom_properties(self):
+        return {key: value for key, value in self.raw.items()
+                if key.startswith('Z_') or key.startswith('z_')}
 
 
 class AlertSet(PredictiveAssetInsightsEntitySet):
@@ -90,6 +109,31 @@ class AlertSet(PredictiveAssetInsightsEntitySet):
             'by': 'type',
         },
     }
+
+    def as_df(self, columns=None, include_all_custom_properties=False):
+        """Return all information on the objects stored in the AlertSet as a pandas dataframe.
+
+        Parameters
+        ----------
+        columns
+            Select the columns (and their order) for the DataFrame.
+        include_all_custom_properties
+            If True, adds ALL custom properties attached to the alerts to the resulting DataFrame.
+            This can only be used when all alerts in the AlertSet are of the same type.
+        """
+        if columns is None:
+            columns = [field.our_name for field in self._element_type._field_map.values() if field.is_exposed]
+
+        if len(self) > 0 and include_all_custom_properties:
+            alert_types = super().as_df(columns=['type'])['type']
+            if alert_types.nunique() > 1:
+                raise RuntimeError('Cannot include custom properties: More than one alert type present in result.')
+            # to preserve order a dict is used instead of a set
+            columns = dict.fromkeys(columns)
+            custom_columns = dict.fromkeys(self[0]._custom_properties.keys())
+            columns.update(custom_columns)
+
+        return super().as_df(columns=columns)
 
 
 def find_alerts(*, extended_filters=(), **kwargs) -> AlertSet:
@@ -121,3 +165,68 @@ def find_alerts(*, extended_filters=(), **kwargs) -> AlertSet:
     endpoint_url = _pai_application_url() + ALERTS_READ_PATH
     object_list = _pai_fetch_data(endpoint_url, unbreakable_filters, breakable_filters)
     return AlertSet([Alert(obj) for obj in object_list])
+
+
+def create_alert(**kwargs) -> Alert:
+    """Create a new alert in the remote system.
+
+    Alerts are immutable. If the specified alert type uses a deduplication period,
+    the remote system will not create a new alert but **ONLY** increase the counter for an existing alert
+    on the same equipment within the deduplication period. This means (1) additional properties supplied are
+    discarded and (2) this function will return the existing alert object as a response.
+
+    Parameters
+    ----------
+    **kwargs
+        Keyword arguments which names correspond to the available properties.
+        Can also be used to supply custom fields (Z_*, z_*) used with the corresponding alert type: in this case the
+        type of the field is not known to Sailor and therefore the value must be strictly given in the format defined by
+        the type as defined by the remote API.
+
+    Returns
+    -------
+    Alert
+        A new alert object as retrieved from PAI after the create succeeded.
+
+    Example
+    -------
+    >>> alert = create_alert(equipment_id='123', triggered_on='2020-07-31T13:23:00Z',
+    ...                      type='PUMP_TEMP_WARN', severity_code=5, indicator_id='ic1',
+    ...                      indicator_group_id='ig1', template_id='t1')
+    """
+    request = _AlertWriteRequest()
+    request.insert_user_input(kwargs, forbidden_fields=['id'])
+    return _create_alert(request)
+
+
+def _create_alert(request) -> Alert:
+    request.validate()
+    endpoint_url = ac_utils._ac_application_url() + ALERTS_WRITE_PATH
+    oauth_client = get_oauth_client('asset_central')
+
+    response = oauth_client.request('POST', endpoint_url, json=request.data)
+    alert_id = re.search(
+                r'[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}',
+                response.decode('utf-8')).group()
+
+    result = find_alerts(id=alert_id)
+    if len(result) != 1:
+        raise RuntimeError('Unexpected error when creating the alert. Please try again.')
+    return result[0]
+
+
+class _AlertWriteRequest(ac_utils._AssetcentralWriteRequest):
+
+    ADD_WRITE_PARAMS = {
+        'custom_properties': _PredictiveAssetInsightsField('custom_properties', None, 'custom_properties')
+    }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__({**Alert._field_map, **self.ADD_WRITE_PARAMS}, *args, **kwargs)
+
+    def insert_user_input(self, input_dict: dict, forbidden_fields=()):
+        custom_properties = {key: input_dict.pop(key) for key in list(input_dict.keys())
+                             if key.startswith('Z_') or key.startswith('z_')}
+        if custom_properties:
+            input_dict['custom_properties'] = custom_properties
+        return super().insert_user_input(input_dict, forbidden_fields=forbidden_fields)

--- a/sailor/pai/constants.py
+++ b/sailor/pai/constants.py
@@ -1,3 +1,4 @@
 """Please store all the constants here."""
 
 ALERTS_READ_PATH = '/alerts/odata/v1/Alerts'
+ALERTS_WRITE_PATH = '/ain/services/api/v1/alerts'  # however, this belongs to assetcentral

--- a/sailor/utils/oauth_wrapper/OAuthServiceImpl.py
+++ b/sailor/utils/oauth_wrapper/OAuthServiceImpl.py
@@ -93,7 +93,11 @@ class OAuth2Client():
         response = session.request(method, url, **req_kwargs)
         if response.ok:
             if response.headers.get('content-type', '').lower() == 'application/json':
-                return response.json()
+                # TODO: remove this workaround when API has been fixed
+                try:
+                    return response.json()
+                except json.JSONDecodeError:
+                    return response.content
             else:
                 return response.content
         else:

--- a/tests/test_sailor/test_assetcentral/test_equipment.py
+++ b/tests/test_sailor/test_assetcentral/test_equipment.py
@@ -149,7 +149,6 @@ class TestEquipment:
             equipment.create_alert(**create_kwargs)
 
 
-
 class TestEquipmentSet:
 
     @pytest.mark.parametrize('function_name', [

--- a/tests/test_sailor/test_assetcentral/test_equipment.py
+++ b/tests/test_sailor/test_assetcentral/test_equipment.py
@@ -124,6 +124,31 @@ class TestEquipment:
         with pytest.raises(RuntimeError, match=f"You cannot set '{expected_offender}' in this request."):
             equipment.create_notification(**create_kwargs)
 
+    @patch('sailor.pai.alert._create_alert')
+    def test_create_alert_builds_request(self, create_mock, make_equipment):
+        equipment = make_equipment(equipmentId='123')
+        create_kwargs = dict(triggered_on='2020-07-31T13:23:00Z',
+                             type='PUMP_TEMP_WARN', severity_code=5)
+        expected_request_dict = {'equipmentId': '123', 'triggeredOn': '2020-07-31T13:23:00Z',
+                                 'alertType': 'PUMP_TEMP_WARN', 'severityCode': 5}
+
+        equipment.create_alert(**create_kwargs)
+
+        create_mock.assert_called_once_with(expected_request_dict)
+
+    @pytest.mark.parametrize('create_kwargs', [
+        ({'id': 123}),
+        ({'equipment_id': 123}),
+        ({'equipmentId': 123})
+    ])
+    def test_create_alert_forbidden_fields_raises(self, create_kwargs, make_equipment):
+        equipment = make_equipment()
+        expected_offender = list(create_kwargs.keys())[0]
+
+        with pytest.raises(RuntimeError, match=f"You cannot set '{expected_offender}' in this request."):
+            equipment.create_alert(**create_kwargs)
+
+
 
 class TestEquipmentSet:
 

--- a/tests/test_sailor/test_assetcentral/test_utils.py
+++ b/tests/test_sailor/test_assetcentral/test_utils.py
@@ -13,11 +13,12 @@ class TestAssetcentralRequest:
             actual.update({'abc': 1})
         assert actual == {'abc': 1}
 
-    def test_setitem_sets_nothing_if_key_known_but_not_writable(self):
+    def test_setitem_sets_nothing_and_warns_if_key_known_but_not_writable(self):
         field_map = {'our_name': _AssetcentralField('our_name', 'their_name_get')}
         actual = _AssetcentralWriteRequest(field_map)
 
-        actual.update({'our_name': 1})
+        with pytest.warns(UserWarning, match="Parameter 'our_name' is not available"):
+            actual.update({'our_name': 1})
 
         assert actual == {}
 

--- a/tests/test_sailor/test_pai/test_alert.py
+++ b/tests/test_sailor/test_pai/test_alert.py
@@ -1,10 +1,46 @@
-from unittest.mock import patch
+from unittest.mock import patch, call
 
 import pytest
+from pandas import Timestamp
 
 from sailor.pai import constants
 from sailor import pai
-from sailor.pai.alert import Alert
+from sailor.pai.utils import _PredictiveAssetInsightsField
+from sailor.pai.alert import Alert, AlertSet, _AlertWriteRequest, create_alert
+
+
+@pytest.fixture
+def make_alert():
+    def maker(**kwargs):
+        kwargs.setdefault('AlertId', 'id')
+        kwargs.setdefault('AlertType', 'alert_type')
+        return Alert(kwargs)
+    return maker
+
+
+@pytest.fixture
+def make_alert_set(make_alert):
+    def maker(**kwargs):
+        alert_defs = [dict() for _ in list(kwargs.values())[0]]
+        for k, values in kwargs.items():
+            for i, value in enumerate(values):
+                alert_defs[i][k] = value
+        return AlertSet([make_alert(**x) for x in alert_defs])
+    return maker
+
+
+@pytest.fixture
+def mock_ac_url():
+    with patch('sailor.assetcentral.utils._ac_application_url') as mock:
+        mock.return_value = 'ac_base_url'
+        yield mock
+
+
+@pytest.fixture
+def mock_pai_url():
+    with patch('sailor.pai.alert._pai_application_url') as mock:
+        mock.return_value = 'pai_base_url'
+        yield mock
 
 
 def get_parameters(test_object):
@@ -50,8 +86,8 @@ class TestAlert():
         expected_attributes = [
             'description', 'severity_code', 'category', 'equipment_name', 'model_name', 'indicator_name',
             'indicator_group_name', 'template_name', 'count', 'status_code', 'triggered_on', 'last_occured_on',
-            'type_description', 'error_code_description', 'type', 'id', 'equipment_id', 'model_id', 'template_id',
-            'indicator_id', 'indicator_group_id', 'notification_id',
+            'type_description', 'error_code_description', 'type', 'source', 'id', 'equipment_id', 'model_id',
+            'template_id', 'indicator_id', 'indicator_group_id', 'notification_id', 'error_code_id',
         ]
 
         fieldmap_public_attributes = [
@@ -59,3 +95,160 @@ class TestAlert():
         ]
 
         assert expected_attributes == fieldmap_public_attributes
+
+    def test_custom_properties_uses_startswith_z(self):
+        alert = Alert({'AlertId': 'id',
+                       'Z_mycustom': 'mycustom', 'z_another': 'another'})
+        assert alert._custom_properties == {'Z_mycustom': 'mycustom', 'z_another': 'another'}
+
+    def test_custom_properties_are_set_as_attributes(self):
+        alert = Alert({'AlertId': 'id',
+                       'Z_mycustom': 'mycustom', 'z_another': 'another'})
+        assert alert.id == 'id'
+        assert alert.Z_mycustom == 'mycustom'
+        assert alert.z_another == 'another'
+
+
+@pytest.mark.parametrize('testdesc,kwargs,expected_cols', [
+    ('default=all noncustom properties',
+        dict(), ['id', 'type']),
+    ('only specified columns',
+        dict(columns=['id', 'Z_mycustom']), ['id', 'Z_mycustom']),
+    ('all properties AND all custom properties',
+        dict(include_all_custom_properties=True), ['id', 'type', 'Z_mycustom', 'z_another']),
+    ('specified AND all custom properties',
+        dict(columns=['id', 'Z_mycustom'], include_all_custom_properties=True), ['id', 'Z_mycustom', 'z_another'])
+])
+def test_alertset_as_df_expects_columns(make_alert_set, monkeypatch,
+                                        kwargs, expected_cols, testdesc):
+    monkeypatch.setattr(Alert, '_field_map', {
+        'id': _PredictiveAssetInsightsField('id', 'AlertId'),
+        'type': _PredictiveAssetInsightsField('type', 'AlertType'),
+    })
+    alert_set = make_alert_set(AlertId=['id1', 'id2', 'id3'],
+                               Z_mycustom=['cust1', 'cust2', 'cust3'],
+                               z_another=['ano1', 'ano2', 'ano3'])
+    actual = alert_set.as_df(**kwargs)
+    assert actual.columns.to_list() == expected_cols
+
+
+def test_alertset_as_df_raises_on_custom_properties_with_multiple_types(make_alert_set, monkeypatch):
+    monkeypatch.setattr(Alert, '_field_map', {
+        'id': _PredictiveAssetInsightsField('id', 'AlertId'),
+        'type': _PredictiveAssetInsightsField('type', 'AlertType'),
+    })
+    alert_set = make_alert_set(AlertId=['id1', 'id2', 'id3'],
+                               AlertType=['type', 'type', 'DIFFERENT_TYPE'],
+                               Z_mycustom=['cust1', 'cust2', 'cust3'],
+                               z_another=['ano1', 'ano2', 'ano3'])
+    with pytest.raises(RuntimeError, match='More than one alert type present in result'):
+        alert_set.as_df(include_all_custom_properties=True)
+
+
+@pytest.mark.filterwarnings('ignore:Unknown name for _AlertWriteRequest parameter found')
+def test_create_alert_create_calls_and_result(mock_ac_url, mock_pai_url, mock_request):
+    input_kwargs = {'param1': 'abc123', 'param2': 'def456'}
+    mock_post_response = b'12345678-1234-1234-1234-1234567890ab'
+    mock_get_response = {'d': {'results': [{'some': 'result'}]}}
+    mock_request.side_effect = [mock_post_response, mock_get_response]
+    expected_request_dict = input_kwargs
+
+    # mock validate so that validation does not fail
+    with patch('sailor.assetcentral.utils._AssetcentralWriteRequest.validate'):
+        actual = create_alert(**input_kwargs)
+
+    mock_request.assert_has_calls([
+        call('POST', 'ac_base_url' + constants.ALERTS_WRITE_PATH, json=expected_request_dict),
+        call('GET', 'pai_base_url' + constants.ALERTS_READ_PATH,
+             params={'$filter': "AlertId eq '12345678-1234-1234-1234-1234567890ab'", '$format': 'json'})])
+    assert type(actual) == Alert
+    assert actual.raw == {'some': 'result'}
+
+
+@pytest.mark.parametrize('find_call_result', [
+    ({'d': {'results': []}}),
+    ({'d': {'results': [{'AlertId': '123'}, {'AlertId': '456'}]}}),
+])
+@pytest.mark.filterwarnings('ignore::sailor.utils.utils.DataNotFoundWarning')
+@patch('sailor.pai.alert._AlertWriteRequest')
+def test_create_alert_raises_when_find_has_no_single_result(mock_wr, mock_pai_url, mock_ac_url, mock_request,
+                                                            find_call_result):
+    successful_create_result = b'12345678-1234-1234-1234-1234567890ab'
+    mock_request.side_effect = [successful_create_result, find_call_result]
+
+    with pytest.raises(RuntimeError, match='Unexpected error'):
+        create_alert()
+
+
+def test_create_alert_integration(mock_pai_url, mock_ac_url, mock_request):
+    create_kwargs = {
+        'triggered_on': '2020-07-31T13:23:02Z',
+        'description': 'Test alert',
+        'type': 'Centrifuge_Overheating',
+        'severity_code': 5,
+        'equipment_id': 'EQUI_ID_001',
+        'template_id': 'TEMPLATE_ID_002',
+        'indicator_group_id': 'IGROUP_ID_003',
+        'indicator_id': 'INDICATOR_ID_004',
+        'source': 'Machine'}
+    expected_request_dict = {
+        'triggeredOn': '2020-07-31T13:23:02Z',
+        'description': 'Test alert',
+        'alertType': 'Centrifuge_Overheating',
+        'severityCode': 5,
+        'equipmentId': 'EQUI_ID_001',
+        'templateId': 'TEMPLATE_ID_002',
+        'indicatorGroupId': 'IGROUP_ID_003',
+        'indicatorId': 'INDICATOR_ID_004',
+        'source': 'Machine'}
+    mock_post_response = b'12345678-1234-1234-1234-1234567890ab'
+    mock_get_response = {'d': {'results': [{
+        '__metadata': {},
+        'EquipmentID': 'EQUI_ID_001',
+        'TriggeredOn': '/Date(1596201782000)/',
+        'SeverityCode': 5,
+        'TemplateID': 'TEMPLATE_ID_002',
+        'Description': 'Test alert',
+        'IndicatorID': 'INDICATOR_ID_004',
+        'Source': 'Machine',
+        'AlertType': 'Centrifuge_Overheating',
+        'IndicatorGroupID': 'IGROUP_ID_003',
+        'AlertId': '12345678-1234-1234-1234-1234567890ab'}
+        ]}}
+    mock_request.side_effect = [mock_post_response, mock_get_response]
+
+    actual = create_alert(**create_kwargs)
+
+    mock_request.assert_has_calls([
+        call('POST', 'ac_base_url/ain/services/api/v1/alerts', json=expected_request_dict),
+        call('GET', 'pai_base_url/alerts/odata/v1/Alerts', params={
+            '$filter': "AlertId eq '12345678-1234-1234-1234-1234567890ab'", '$format': 'json'})])
+    assert type(actual) == Alert
+    assert actual.id == '12345678-1234-1234-1234-1234567890ab'
+    assert actual.triggered_on == Timestamp('2020-07-31T13:23:02Z')
+    create_kwargs.pop('triggered_on')
+    for property_name, value in create_kwargs.items():
+        assert getattr(actual, property_name) == value
+
+
+def test_alertwriterequest_custom_properties():
+    create_kwargs = {
+        'triggered_on': '2020-07-31T13:23:02Z',
+        'type': 'Centrifuge_Overheating',
+        'severity_code': 5,
+        'equipment_id': 'EQUI_ID_001',
+        'Z_mycustom': 'some custom value',
+        'z_another': 'another custom value'}
+    expected_request_dict = {
+        'triggeredOn': '2020-07-31T13:23:02Z',
+        'alertType': 'Centrifuge_Overheating',
+        'severityCode': 5,
+        'equipmentId': 'EQUI_ID_001',
+        'custom_properties': {'Z_mycustom': 'some custom value',
+                              'z_another': 'another custom value'}
+    }
+
+    request = _AlertWriteRequest()
+    request.insert_user_input(create_kwargs)
+
+    assert request == expected_request_dict


### PR DESCRIPTION
# Description

Alerts support the use case of automated machine created events for an equipment.

A single alert can be created using the sailor.pai.create_alert function.
The create_alert function uses the same syntax and semantics as the create_notification function.
Please see the tutorial for creating notifications.
Everything else should become clear reading the API documentation (create_alert).

Specifying and reading custom fields on alerts is supported, too.

# Checklist

Mark "not applicable" if item on the list does not apply to this pull request.

- [x] I have created/adapted unit tests for new code
  - [ ] not applicable 
- [ ] I have added new dependencies as described at the [Contributing](https://sap.github.io/project-sailor/contributing.html#requirements-management) page
  - [x] not applicable 
- [x] I have made corresponding changes to the documentation (incl. tutorial, etc.)
  - [ ] not applicable 
- [x] I have provided release notes (in description or as comment) if this PR is a new feature OR a change worth mentioning for next release
  - [ ] not applicable 
- [x] I have obtained API approvals if a new SAP API or endpoint is used
  - [ ] not applicable 
