### PR TITLE
Test setup hardening: Warnings and latest dependency versions

### DIFF
--- a/.github/workflows/main_validation.yml
+++ b/.github/workflows/main_validation.yml
@@ -2,7 +2,7 @@ name: Validation
 
 on:
   push:
-    branches: [main, ci/main_requirements]
+    branches: [main]
 
 jobs:
   pytest:

--- a/.github/workflows/main_validation.yml
+++ b/.github/workflows/main_validation.yml
@@ -2,14 +2,16 @@ name: Validation
 
 on:
   push:
-    branches: [main]
+    branches: [main, ci/main_requirements]
 
 jobs:
   pytest:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ['3.8', '3.9']
+        requirements: ['.in', '.txt']
 
     steps:
       - uses: actions/setup-python@v2
@@ -21,7 +23,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r .ci/requirements_test.txt
-          pip install -r requirements.txt
+          pip install -r "requirements${{ matrix.requirements }}"
 
       - name: Run pytest
         run: |

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,10 @@ add-ignore = D104,D404
 
 
 [tool:pytest]
+# turn all warnings into errors - expected warnings our library throws must be tested for or filtered out in the test.
+# unexpected warnings must be fixed. if not possible immediately, add to the list below.
 filterwarnings = default
+    error::Warning
 
 
 [coverage:run]


### PR DESCRIPTION
# Description

- Test the main branch additionally on latest python dependencies. 
A green test with requirements.txt is only valid for those exact versions. A user may install our library at any point in time with more recent versions of the dependencies available. We would like to get a hold of possible dependency issues.

- Fail tests on warnings.
Catch DeprecationWarnings/FutureWarnings early. Also catch warnings that we might cause involuntarily.

# Checklist

Mark "not applicable" if item on the list does not apply to this pull request.

- [ ] I have created/adapted unit tests for new code
  - [x] not applicable 
- [ ] I have added new dependencies as described at the [Contributing](https://sap.github.io/project-sailor/contributing.html#requirements-management) page
  - [x] not applicable 
- [ ] I have made corresponding changes to the documentation (incl. tutorial, etc.)
  - [x] not applicable 
- [ ] I have provided release notes (in description or as comment) if this PR is a new feature OR a change worth mentioning for next release
  - [x] not applicable 
- [ ] I have obtained API approvals if a new SAP API or endpoint is used
  - [x] not applicable 
