### PR TITLE
DMC: Support Visual Inspection Scenarios

### DIFF
--- a/sailor/dmc/constants.py
+++ b/sailor/dmc/constants.py
@@ -1,0 +1,7 @@
+"""Please store all the constants for DMC here."""
+
+AIML_GROUP = '/aiml/v1'
+
+ACTIVE_SCENARIOS = '/active-scenarios'
+INSPECTION_LOG = '/inspectionLog'
+INSPECTION_LOGS_FOR_CONTEXT = '/inspectionLogsForContext'

--- a/sailor/dmc/inspection_log.py
+++ b/sailor/dmc/inspection_log.py
@@ -1,0 +1,317 @@
+"""
+Inspection Log module can be used to retrieve Inspection Log information from Digital Manufacturing Cloud.
+
+Classes are provided for individual Inspection Logs as well as groups of Inspection Logs (InspectionLogSet).
+"""
+from base64 import b64decode
+from typing import Any, Dict, List, Tuple
+
+import pandas as pd
+from sailor import _base
+
+from .constants import AIML_GROUP, INSPECTION_LOG, INSPECTION_LOGS_FOR_CONTEXT
+from .utils import (DigitalManufacturingCloudEntity, DigitalManufacturingCloudEntitySet,
+                    _DigitalManufacturingCloudField, _dmc_application_url, _dmc_fetch_data)
+
+# TODO: replace inspectionLogTime by a more suitable id as soon as one is available via the API
+_INSPECTION_LOG_FIELDS = [
+    _DigitalManufacturingCloudField('file_id', 'fileId'),
+    _DigitalManufacturingCloudField('id', 'inspectionLogTime'),
+    _DigitalManufacturingCloudField('type', 'inspectionType'),
+    _DigitalManufacturingCloudField('view_name', 'inspectionViewName'),
+    _DigitalManufacturingCloudField('logged_annotation', 'loggedAnnotation'),
+    _DigitalManufacturingCloudField('logged_nc_code', 'loggedNCCode'),
+    _DigitalManufacturingCloudField('material', 'material'),
+    _DigitalManufacturingCloudField('operation', 'operation'),
+    _DigitalManufacturingCloudField('plant', 'plant'),
+    _DigitalManufacturingCloudField('predicted_annotation', 'predictedAnnotation'),
+    _DigitalManufacturingCloudField('predicted_class', 'predictedClass'),
+    _DigitalManufacturingCloudField('predicted_nc_code', 'predictedNCCode'),
+    _DigitalManufacturingCloudField('resource', 'resource'),
+    _DigitalManufacturingCloudField('routing', 'routing'),
+    _DigitalManufacturingCloudField('sfc', 'sfcId'),
+    _DigitalManufacturingCloudField('source', 'source'),
+]
+
+# all fields which can be used as request parameters for the endpoint /inspectionLogsForContext
+_INSPECTION_LOG_FILTER_FIELDS = {
+    'file_id': 'fileID',
+    'from_date': 'fromDate',
+    'to_date': 'toDate',
+    'inspection_view_name': 'inspectionViewName',
+    'logged_nc_code': 'loggedNCCode',
+    'material': 'material',
+    'operation': 'operation',
+    'plant': 'plant',
+    'resource': 'resource',
+    'routing': 'routing',
+    'scenario_id': 'scenarioID',
+    'scenario_version': 'scenarioVersion',
+    'sfc': 'sfc',
+    'skip': 'skip',
+    'source': 'source',
+    'top': 'top',
+    'id': 'inspectionLogTime',
+}
+
+
+@_base.add_properties
+class InspectionLog(DigitalManufacturingCloudEntity):
+    """Digital Manufacturing Cloud InspectionLog Object."""
+
+    _field_map = {field.our_name: field for field in _INSPECTION_LOG_FIELDS}
+
+    # TODO: Review whether to make this function private, do some remapping to fit syntax with INSPECTION_LOG_FIELDS
+    # or add the properties to the Inspection Logs returned by find_inspection_logs()
+    def _get_details(self) -> Dict[str, Any]:
+        """Fetches details about this specific Inspecton Log and if applicable the corresponding image as
+        base64-encoded string from Digital Manufacturing Cloud.
+        """
+        endpoint_url = _dmc_application_url() + AIML_GROUP + INSPECTION_LOG
+
+        # Material and operation might not be strictly necessary for identification of the correct Inspection Log,
+        # however, if they are excluded the response will (or at the very least might) not contain any fileContent.
+        params = {
+            'id': self.id,
+            'file_id': self.file_id,
+            'plant': self.plant,
+            'sfc': self.sfc,
+            'material': self.material,
+            'operation': self.operation,
+        }
+
+        response = _dmc_fetch_data(endpoint_url, params, _INSPECTION_LOG_FILTER_FIELDS)
+
+        return response
+
+
+class InspectionLogSet(DigitalManufacturingCloudEntitySet):
+    """Class representing a group of InspectionLogs."""
+
+    _element_type = InspectionLog
+
+    def _get_details_and_images(self) -> Tuple[List[Dict[str, Any]], Dict[str, bytes]]:
+        """Fetches details with :ref:`_get_details()` and decodes the base64-encoded images to bytes.
+        Returns a list containing all details for Inspection Logs containing images and a dict mapping bytes to fileId.
+        """
+
+        details = []
+        images = {}
+
+        for inspection_log in self.elements:
+
+            inspection_log_details = inspection_log._get_details()
+
+            if 'fileContent' not in inspection_log_details.keys():
+                continue
+
+            filename = inspection_log_details['fileId']
+
+            image_bytes = b64decode(inspection_log_details['fileContent'])
+
+            images[filename] = image_bytes
+
+            inspection_log_details.pop('fileContent')
+
+            details.append(inspection_log_details)
+
+        return details, images
+
+    def _remove_duplicates(self, df) -> pd.DataFrame:
+        """Removes in respect to fileId duplicate Inspection Logs from DataFrame, keeping only the most recent."""
+        df = df.sort_values('inspectionLogTime', ascending=False)
+        df = df.drop_duplicates(['fileId'])
+        return df
+
+    def _remove_images_not_in_df(self, df, images) -> Dict[str, bytes]:
+        """Removes all images from the images-dict that do not have a label in the df."""
+        available_files = df['fileId'].tolist()
+        filtered_images = {file_id: images[file_id] for file_id in available_files}
+        return filtered_images
+
+    def as_binary_classification_input(self, remove_duplicates=True):
+        """Returns a DataFrame containing the details of all Inspection Logs that contain an image and the isConformant-flag,
+        and a dictionary mapping the bytes of those images to the corresponding fileId."""
+        details, images = self._get_details_and_images()
+
+        df = pd.DataFrame()
+
+        for details_item in details:
+            if 'isConformant' not in details_item.keys():
+                continue
+
+            details_item.update(details_item['context'])
+            details_item.pop('context')
+            details_item.pop('fileID', None)
+
+            details_item.pop('scenarioVersion', None)
+            details_item.pop('scenarioId', None)
+
+            details_item.pop('predictions', None)
+            details_item.pop('loggedNCS', None)
+
+            df = df.append(details_item, ignore_index=True)
+
+        df['inspectionLogTime'] = pd.to_datetime(df['inspectionLogTime'])
+
+        df['isConformant'] = df['isConformant'].astype('boolean')
+
+        if remove_duplicates:
+            df = self._remove_duplicates(df)
+
+        images = self._remove_images_not_in_df(df, images)
+
+        return df, images
+
+    def as_multilabel_classification_input(self, remove_duplicates=True) -> Tuple[pd.DataFrame, Dict[str, bytes]]:
+        """Returns a DataFrame containing the details of all Inspection Logs that contain an image and either predictions
+        or logged non-conformancies, and a dictionary mapping the bytes of those images to the corresponding fileId."""
+        details, images = self._get_details_and_images()
+
+        df = pd.DataFrame()
+
+        for details_item in details:
+            if (len(details_item['predictions']) == 0) and (len(details_item['loggedNCS']) == 0):
+                continue
+
+            details_item.update(details_item['context'])
+            details_item.pop('context')
+            details_item.pop('fileID', None)
+
+            details_item.pop('scenarioVersion', None)
+            details_item.pop('scenarioId', None)
+
+            df = df.append(details_item, ignore_index=True)
+
+        df['inspectionLogTime'] = pd.to_datetime(df['inspectionLogTime'])
+
+        df['isConformant'] = df['isConformant'].astype('boolean')
+
+        if remove_duplicates:
+            df = self._remove_duplicates(df)
+
+        images = self._remove_images_not_in_df(df, images)
+
+        return df, images
+
+    def _contains_bounding_box(self, details_item) -> bool:
+        """Looks into predictions and logged non-conformancies and return whether one of both
+        contains a bounding box."""
+        for prediction in details_item['predictions']:
+            if 'predictionBoundingBoxCoords' in prediction.keys():
+                if prediction['predictionBoundingBoxCoords'] != '[]':
+                    return True
+
+        for logged_ncs in details_item['loggedNCS']:
+            if 'defectBoundingBoxCoords' in logged_ncs.keys():
+                if logged_ncs['defectBoundingBoxCoords'] != '[]':
+                    return True
+
+        return False
+
+    def as_object_detection_input(self, remove_duplicates=True) -> Tuple[pd.DataFrame, Dict[str, bytes]]:
+        """Returns a DataFrame containing the details of all Inspection Logs that contain an image and whoose either
+        predictions or logged non-conformancies countain bounding boxes, and a dictionary mapping the bytes of those
+        images to the corresponding fileId. Removes all prediction/non-conformanicies without bounding boxes."""
+        details, images = self._get_details_and_images()
+
+        df = pd.DataFrame()
+
+        for details_item in details:
+            if not self._contains_bounding_box(details_item):
+                continue
+
+            details_item['predictions'] = [
+                prediction for prediction in details_item['predictions']
+                if 'predictionBoundingBoxCoords' in prediction.keys()
+            ]
+
+            details_item['loggedNCS'] = [
+                prediction for prediction in details_item['loggedNCS']
+                if 'defectBoundingBoxCoords' in prediction.keys()
+            ]
+
+            details_item.update(details_item['context'])
+            details_item.pop('context')
+            details_item.pop('fileID', None)
+
+            details_item.pop('scenarioVersion', None)
+            details_item.pop('scenarioId', None)
+
+            df = df.append(details_item, ignore_index=True)
+
+        df['inspectionLogTime'] = pd.to_datetime(df['inspectionLogTime'])
+
+        df['isConformant'] = df['isConformant'].astype('boolean')
+
+        if remove_duplicates:
+            df = self._remove_duplicates(df)
+
+        images = self._remove_images_not_in_df(df, images)
+
+        return df, images
+
+    def as_ml_input(self, remove_duplicates=True) -> Tuple[pd.DataFrame, Dict[str, bytes]]:
+        """Returns a DataFrame containing the details of all Inspection Logs that contain an image and a dictionary
+        mapping the bytes of those images to the corresponding fileId. Keeps the DataFrame generic in case the
+        user wants to do their own data preparation."""
+        details, images = self._get_details_and_images()
+
+        df = pd.DataFrame()
+
+        for details_item in details:
+            details_item.update(details_item['context'])
+            details_item.pop('context')
+            details_item.pop('fileID', None)
+
+            details_item.pop('scenarioVersion', None)
+            details_item.pop('scenarioId', None)
+
+            df = df.append(details_item, ignore_index=True)
+
+        df['inspectionLogTime'] = pd.to_datetime(df['inspectionLogTime'])
+
+        df['isConformant'] = df['isConformant'].astype('boolean')
+
+        if remove_duplicates:
+            df = self._remove_duplicates(df)
+
+        return df, images
+
+
+def find_inspection_logs(**kwargs) -> InspectionLogSet:
+    """Fetch Inspection Logs from Digital Manufacturing Cloud with the applied filters, return an InspectionLogSet.
+
+    Any named keyword arguments are applied as equality filters, i.e. the name of the InspectionLog property is checked
+    against the value of the keyword argument. Arguments 'scenario_id' and 'scenario_version' are required.
+
+    Parameters
+    ----------
+    **kwargs
+        See :ref:`filter`.
+
+    Examples
+    --------
+    Find all Inspection Logs with scenario_id 'MyScenarioID' and scenario_version 1:
+
+      find_inspection_logs(scenario_id='MyScenarioID', scenario_version=1)
+
+    Find all Inspection Logs with scenario_id 'MyScenarioID', scenario_version 1 and Inspection
+    Log Time 31.01.2021 08:30:00:000:
+
+      kwargs = {
+          'scenario_id': 'MyScenarioID',
+          'scenario_version': 1,
+          'id': '2021-31-01 08:30:00:000',
+      }
+
+      find_inspection_logs(**kwargs)
+    """
+    if (not ('scenario_id' in kwargs.keys())) or (not ('scenario_version' in kwargs.keys())):
+        raise ValueError('Please specify a scenario_id and a scenario_version.')
+
+    endpoint_url = _dmc_application_url() + AIML_GROUP + INSPECTION_LOGS_FOR_CONTEXT
+
+    object_list = _dmc_fetch_data(endpoint_url, kwargs, _INSPECTION_LOG_FILTER_FIELDS)
+
+    return InspectionLogSet([InspectionLog(obj) for obj in object_list])

--- a/sailor/dmc/scenario.py
+++ b/sailor/dmc/scenario.py
@@ -1,0 +1,100 @@
+"""
+Scenario module can be used to retrieve Scenario information from Digital Manufacturing Cloud.
+
+Classes are provided for individual Scenarios as well as groups of Scenarios (ScenarioSet).
+"""
+
+from sailor import _base
+from sailor.dmc.inspection_log import InspectionLogSet, find_inspection_logs
+
+from .constants import ACTIVE_SCENARIOS, AIML_GROUP
+from .utils import (DigitalManufacturingCloudEntity, DigitalManufacturingCloudEntitySet,
+                    _DigitalManufacturingCloudField, _dmc_application_url, _dmc_fetch_data)
+
+_SCENARIO_FIELDS = [
+    _DigitalManufacturingCloudField('short_description', 'scenarioDescription'),
+    _DigitalManufacturingCloudField('id', 'scenarioId'),
+    _DigitalManufacturingCloudField('name', 'scenarioName'),
+    _DigitalManufacturingCloudField('objective', 'scenarioObjective'),
+    _DigitalManufacturingCloudField('status', 'scenarioStatus'),
+    _DigitalManufacturingCloudField('version', 'scenarioVersion'),
+    _DigitalManufacturingCloudField('created_at', 'scenarioCreatedAt'),
+    _DigitalManufacturingCloudField('changed_at', 'scenarioChangedAt'),
+    _DigitalManufacturingCloudField('_combinations', 'scenarioCombinations'),
+    _DigitalManufacturingCloudField('_deployment', 'deployment')
+]
+
+# all fields which can be used as request parameters for the endpoint /active-scenarios
+_SCENARIO_FILTER_FIELDS = {
+    'deployment_type': 'deploymentType',
+    'material': 'material',
+    'operation': 'operation',
+    'plant': 'plant',
+    'resource': 'resource',
+    'routing': 'routing',
+    'sfc': 'sfc',
+}
+
+
+@_base.add_properties
+class Scenario(DigitalManufacturingCloudEntity):
+    """Digital Manufacturing Cloud Scenario Object."""
+
+    _field_map = {field.our_name: field for field in _SCENARIO_FIELDS}
+
+    def __repr__(self) -> str:
+        """Return a very short string representation."""
+        name = getattr(self, 'name', getattr(self, 'short_description', None))
+        return f'{self.__class__.__name__}(name="{name}", id="{self.id}")'
+
+    def get_inspection_logs(self) -> InspectionLogSet:
+        """Fetches all Inspection Logs belonging to this Scenario from Digital Manufacturing Cloud.
+
+        For further details see :ref:`find_inspection_logs()`
+        """
+        return find_inspection_logs(
+            scenario_id=self.id,
+            scenario_version=self.version,
+        )
+
+
+class ScenarioSet(DigitalManufacturingCloudEntitySet):
+    """Class representing a group of Scenarios."""
+
+    _element_type = Scenario
+
+
+def find_scenarios(**kwargs) -> ScenarioSet:
+    """Fetch Scenarios from Digital Manufacturing Cloud with the applied filters, return a ScenarioSet.
+
+    Any named keyword arguments are applied as equality filters, i.e. the name of the Scenario property is checked
+    against the value of the keyword argument. A combination of 'plant' and 'sfc' or 'plant', 'material' and
+    'operation' is required.
+
+    Parameters
+    ----------
+    **kwargs
+        See :ref:`filter`.
+
+    Examples
+    --------
+    Find all Scenarios with plant 'MyPlant' and sfc 'MySFC':
+
+      find_scenarios(plant='MyPlant', sfc='MySFC')
+
+    Find all Scenarios with plant 'MyPlant', operation 'MyOperation' and material 'MyMaterial':
+
+      kwargs = {
+          'plant': 'MyPlant',
+          'operation': 'MyOperation',
+          'material': 'MyMaterial',
+      }
+
+      find_scenarios(**kwargs)
+    """
+
+    endpoint_url = _dmc_application_url() + AIML_GROUP + ACTIVE_SCENARIOS
+
+    object_list = _dmc_fetch_data(endpoint_url, kwargs, _SCENARIO_FILTER_FIELDS)
+
+    return ScenarioSet([Scenario(obj) for obj in object_list])

--- a/sailor/dmc/utils.py
+++ b/sailor/dmc/utils.py
@@ -1,0 +1,63 @@
+"""Module for various utility functions, in particular those related to fetching data from remote oauth endpoints."""
+
+import logging
+import warnings
+
+from sailor import _base
+
+from ..utils.config import SailorConfig
+from ..utils.oauth_wrapper.clients import get_oauth_client
+from ..utils.utils import DataNotFoundWarning
+
+LOG = logging.getLogger(__name__)
+LOG.addHandler(logging.NullHandler())
+
+
+def _dmc_application_url():
+    """Return the Digital Manufacturing Cloud application URL from the SailorConfig."""
+    return SailorConfig.get('dmc', 'application_url')
+
+
+def _dmc_fetch_data(endpoint_url, filters={}, filter_fields={}):
+
+    oauth_client = get_oauth_client('dmc')
+
+    query_params = {}
+    not_our_term = []
+
+    for k, v in filters.items():
+        if k in filter_fields.keys():
+            key = filter_fields[k]
+        else:
+            key = k
+            not_our_term.append(key)
+
+        query_params[key] = str(v)
+
+    if len(not_our_term) > 0:
+        warnings.warn(f'Following parameters are not in our terminology: {not_our_term}', stacklevel=3)
+
+    result = oauth_client.request('GET', endpoint_url, params=query_params)
+
+    if len(result) == 0:
+        warnings.warn(DataNotFoundWarning(), stacklevel=2)
+
+    return result
+
+
+class _DigitalManufacturingCloudField(_base.MasterDataField):
+    """Specify a field in Digital Manufacturing Cloud."""
+
+    pass
+
+
+class DigitalManufacturingCloudEntity(_base.MasterDataEntity):
+    """Common base class for DMC entities."""
+
+    pass
+
+
+class DigitalManufacturingCloudEntitySet(_base.MasterDataEntitySet):
+    """Baseclass to be used in all Sets of DMC objects."""
+
+    pass

--- a/sailor/utils/config.py
+++ b/sailor/utils/config.py
@@ -1,11 +1,11 @@
 """Provides configuration management for Sailor."""
-from collections import namedtuple
-from contextlib import contextmanager
-import os
-import logging
 import json
+import logging
+import os
 import sys
 import warnings
+from collections import namedtuple
+from contextlib import contextmanager
 
 import yaml
 
@@ -14,7 +14,7 @@ from .utils import DataNotFoundWarning
 LOG = logging.getLogger(__name__)
 LOG.addHandler(logging.NullHandler())
 
-CONFIG_PROPERTIES = ('asset_central', 'sap_iot', 'predictive_asset_insights')
+CONFIG_PROPERTIES = ('asset_central', 'sap_iot', 'predictive_asset_insights', 'dmc')
 
 
 @contextmanager
@@ -85,8 +85,10 @@ class SailorConfig(namedtuple('SailorConfig', CONFIG_PROPERTIES, defaults=(None,
             LOG.info('Successfully loaded config from environment.')
             return SailorConfig.config
 
-        yaml_paths = [os.getenv('SAILOR_CONFIG_PATH', os.path.join(os.path.abspath(os.curdir), 'config.yml')),
-                      os.path.join(os.path.abspath(os.path.dirname(sys.argv[0])), 'config.yml')]
+        yaml_paths = [
+            os.getenv('SAILOR_CONFIG_PATH', os.path.join(os.path.abspath(os.curdir), 'config.yml')),
+            os.path.join(os.path.abspath(os.path.dirname(sys.argv[0])), 'config.yml')
+        ]
         yaml_paths = [p for p in yaml_paths if os.path.exists(p)]
         try:
             yaml_config_path = yaml_paths[0]
@@ -108,7 +110,7 @@ class SailorConfig(namedtuple('SailorConfig', CONFIG_PROPERTIES, defaults=(None,
         Uses ``SAILOR_CONFIG_JSON`` in environment. Value needs to be JSON encoded.
         """
         config_dict = json.loads(os.environ['SAILOR_CONFIG_JSON'])
-        with try_log(TypeError, lambda e: 'Missing configuration parameter(s): %s' % str(e)[str(e).find(':')+2:]):
+        with try_log(TypeError, lambda e: 'Missing configuration parameter(s): %s' % str(e)[str(e).find(':') + 2:]):
             return cls(**config_dict)
 
     @classmethod
@@ -116,7 +118,7 @@ class SailorConfig(namedtuple('SailorConfig', CONFIG_PROPERTIES, defaults=(None,
         """Load config from YAML file."""
         with open(path, 'r') as f:
             config_dict = yaml.safe_load(f)
-        with try_log(TypeError, lambda e: 'Missing configuration parameter(s): %s' % str(e)[str(e).find(':')+2:]):
+        with try_log(TypeError, lambda e: 'Missing configuration parameter(s): %s' % str(e)[str(e).find(':') + 2:]):
             return cls(**config_dict)
 
 

--- a/tests/test_sailor/test_dmc/test_inspection_log.py
+++ b/tests/test_sailor/test_dmc/test_inspection_log.py
@@ -1,0 +1,598 @@
+from base64 import b64decode
+from unittest.mock import call, patch
+
+import pandas as pd
+import pytest
+from sailor.dmc.inspection_log import (InspectionLog, InspectionLogSet, find_inspection_logs)
+
+_SCENARIO_ID = '123'
+_SCENARIO_VERSION = 1
+_FILE_1 = 'File1.png'
+_FILE_2 = 'File2.png'
+_TIME_1 = '2000-01-01 00:00:00.000'
+_TIME_2 = '2000-01-02 00:00:00.000'
+_TIME_3 = '2000-01-03 00:00:00.000'
+# this is a dummy 1x1 pixel pink png since it has to be something base64-decodable
+_FILE_1_CONTENT = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z/C/HgAGgwJ/lK3Q6wAAAABJRU5ErkJggg=='
+# this is a dummy 1x1 pixel green png since it has to be something base64-decodable
+_FILE_2_CONTENT = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP0/M9QDwAEqgHJZfPahwAAAABJRU5ErkJggg=='
+_FILE_CONTENT_TYPE = 'image/png'
+_TYPE = 'Example_Type'
+_PLANT = 'Example_Plant'
+_MATERIAL = 'Example_Material'
+_OPERATION = 'Example_Operation'
+_RESOURCE = 'Example_Resource'
+_ROUTING = 'Example_Routing'
+_SFC = 'Example_SFC'
+_SOURCE = 'Example_Source'
+_VIEW_NAME = 'default'
+_NC_1 = 'NC_1'
+_NC_1_CLASS = 'NC_1_Class'
+_NC_2 = 'NC_2'
+_NC_2_CLASS = 'NC_2_Class'
+_NC_3 = 'NC_3'
+_NC_3_CLASS = 'NC_3_Class'
+
+_BB_NC_1_LOG = '[{"type":"rect","x":0.8,"y":0.7,"w":0.1,"h":0.1,"score":0.99}]'
+_BB_NC_1_PRED = '[{"type":"rect","x":0.8,"y":0.7,"w":0.1,"h":0.1,"score":0.95}]'
+_BB_NC_3_LOG = '[{"type":"rect","x":0.4,"y":0.3,"w":0.4,"h":0.2,"score":0.85}]'
+_BB_NC_3_PRED = '[{"type":"rect","x":0.4,"y":0.3,"w":0.4,"h":0.2,"score":0.89}]'
+
+_MOCK_RESPONSE = [{
+    'fileId': _FILE_1,
+    'inspectionLogTime': _TIME_1,
+    'inspectionType': _TYPE,
+    'inspectionViewName': _VIEW_NAME,
+    'loggedAnnotation': f'{_NC_1}:{_BB_NC_1_LOG};{_NC_3}:{_BB_NC_3_LOG}',
+    'loggedNCCode': f'{_NC_1};{_NC_3}',
+    'material': _MATERIAL,
+    'operation': _OPERATION,
+    'plant': _PLANT,
+    'predictedAnnotation': f'{_NC_1}:{_BB_NC_1_PRED};{_NC_3}:{_BB_NC_3_PRED}',
+    'predictedClass': f'{_NC_1_CLASS}:0.95;{_NC_3_CLASS}:0.89',
+    'predictedNCCode': f'{_NC_1}:0-95;{_NC_3}:0.89',
+    'resource': _RESOURCE,
+    'routing': _ROUTING,
+    'sfcId': _SFC,
+    'source': _SOURCE,
+}, {
+    'fileId': _FILE_2,
+    'inspectionLogTime': _TIME_2,
+    'inspectionType': _TYPE,
+    'inspectionViewName': _VIEW_NAME,
+    'material': _MATERIAL,
+    'operation': _OPERATION,
+    'plant': _PLANT,
+    'predictedAnnotation': f'{_NC_2}:[]',
+    'predictedClass': f'{_NC_2_CLASS}:0.75',
+    'predictedNCCode': f'{_NC_2}:0.75',
+    'resource': _RESOURCE,
+    'routing': _ROUTING,
+    'sfcId': _SFC,
+    'source': _SOURCE,
+}, {
+    'fileId': _FILE_2,
+    'inspectionLogTime': _TIME_3,
+    'inspectionType': _TYPE,
+    'inspectionViewName': _VIEW_NAME,
+    'material': _MATERIAL,
+    'operation': _OPERATION,
+    'plant': _PLANT,
+    'resource': _RESOURCE,
+    'routing': _ROUTING,
+    'sfcId': _SFC,
+    'source': _SOURCE,
+}]
+
+_DETAILS_1 = {
+    'context': {
+        'plant': _PLANT,
+        'sfc': _SFC,
+        'material': _MATERIAL,
+        'operation': _OPERATION,
+        'resource': _RESOURCE,
+        'routing': _ROUTING,
+        'source': _SOURCE,
+        'inspectionViewName': _VIEW_NAME,
+    },
+    'fileContent': _FILE_1_CONTENT,
+    'fileContentType': _FILE_CONTENT_TYPE,
+    'fileId': _FILE_1,
+    'inspectionLogTime': _TIME_1,
+    'isConformant': False,
+    'loggedNCS': [{
+        'defectBoundingBoxCoords': _BB_NC_1_LOG,
+        'ncCode': _NC_1,
+    }, {
+        'defectBoundingBoxCoords': _BB_NC_3_LOG,
+        'ncCode': _NC_3,
+    }],
+    'predictions': [{
+        'ncCode': _NC_1,
+        'predictionBoundingBoxCoords': _BB_NC_1_PRED,
+        'predictionClass': _NC_1_CLASS,
+        'predictionScore': 0.95,
+    }, {
+        'ncCode': _NC_3,
+        'predictionBoundingBoxCoords': _BB_NC_3_PRED,
+        'predictionClass': _NC_3_CLASS,
+        'predictionScore': 0.89,
+    }],
+    'scenarioID': _SCENARIO_ID,
+    'scenarioVersion': _SCENARIO_VERSION,
+}
+
+_DETAILS_2 = {
+    'context': {
+        'plant': _PLANT,
+        'sfc': _SFC,
+        'material': _MATERIAL,
+        'operation': _OPERATION,
+        'resource': _RESOURCE,
+        'routing': _ROUTING,
+        'source': _SOURCE,
+        'inspectionViewName': _VIEW_NAME,
+    },
+    'fileContent': _FILE_2_CONTENT,
+    'fileContentType': _FILE_CONTENT_TYPE,
+    'fileId': _FILE_2,
+    'inspectionLogTime': _TIME_2,
+    'loggedNCS': [],
+    'predictions': [{
+        'isLogged': False,
+        'ncCode': _NC_2,
+        'predictionClass': _NC_2_CLASS,
+        'predictionScore': 0.75,
+    }],
+    'scenarioID': _SCENARIO_ID,
+    'scenarioVersion': _SCENARIO_VERSION,
+}
+
+_DETAILS_3 = {
+    'context': {
+        'plant': _PLANT,
+        'sfc': _SFC,
+        'material': _MATERIAL,
+        'operation': _OPERATION,
+        'resource': _RESOURCE,
+        'routing': _ROUTING,
+        'source': _SOURCE,
+        'inspectionViewName': _VIEW_NAME,
+    },
+    'fileContent': _FILE_2_CONTENT,
+    'fileContentType': _FILE_CONTENT_TYPE,
+    'fileId': _FILE_2,
+    'inspectionLogTime': _TIME_3,
+    'isConformant': True,
+    'loggedNCS': [],
+    'predictions': [],
+    'scenarioID': _SCENARIO_ID,
+    'scenarioVersion': _SCENARIO_VERSION,
+}
+
+
+@pytest.fixture
+def mock_url():
+    with patch('sailor.dmc.inspection_log._dmc_application_url') as mock:
+        mock.return_value = 'base_url'
+        yield mock
+
+
+@pytest.fixture
+def mock_fetch():
+    with patch('sailor.dmc.inspection_log._dmc_fetch_data') as mock:
+        mock.return_value = _MOCK_RESPONSE
+        yield mock
+
+
+@pytest.fixture
+def mock_details():
+    with patch('sailor.dmc.inspection_log.InspectionLog._get_details') as mock:
+        mock.return_value = 'dummy'
+        yield mock
+
+
+def test_expected_public_attributes_are_present():
+    expected_attributes = [
+        'file_id', 'id', 'type', 'view_name', 'logged_annotation', 'logged_nc_code', 'material', 'operation', 'plant',
+        'predicted_annotation', 'predicted_class', 'predicted_nc_code', 'resource', 'routing', 'sfc', 'source'
+    ]
+
+    fieldmap_public_attributes = [field.our_name for field in InspectionLog._field_map.values() if field.is_exposed]
+
+    assert expected_attributes == fieldmap_public_attributes
+
+
+def test_correct_arguments(mock_url, mock_fetch):
+
+    scenario_id = '123'
+    scenario_version = 1
+
+    expected_url = 'base_url/aiml/v1/inspectionLogsForContext'
+
+    expected_filters = {
+        'scenario_id': '123',
+        'scenario_version': 1,
+    }
+
+    expected_filter_fields = {
+        'file_id': 'fileID',
+        'from_date': 'fromDate',
+        'to_date': 'toDate',
+        'inspection_view_name': 'inspectionViewName',
+        'logged_nc_code': 'loggedNCCode',
+        'material': 'material',
+        'operation': 'operation',
+        'plant': 'plant',
+        'resource': 'resource',
+        'routing': 'routing',
+        'scenario_id': 'scenarioID',
+        'scenario_version': 'scenarioVersion',
+        'sfc': 'sfc',
+        'skip': 'skip',
+        'source': 'source',
+        'top': 'top',
+        'id': 'inspectionLogTime',
+    }
+
+    find_inspection_logs(scenario_id=scenario_id, scenario_version=scenario_version)
+
+    mock_fetch.assert_called_once_with(expected_url, expected_filters, expected_filter_fields)
+
+
+def test_correct_inspection_log_object(mock_url, mock_fetch):
+    kwargs = {
+        'scenario_id': '123',
+        'scenario_version': 1,
+    }
+
+    inspection_logs = find_inspection_logs(**kwargs)
+
+    assert len(inspection_logs) == 3
+    assert type(inspection_logs) == InspectionLogSet
+
+    expected_attributes = [{
+        'file_id': _FILE_1,
+        'id': _TIME_1,
+        'type': _TYPE,
+        'view_name': _VIEW_NAME,
+        'logged_annotation': f'{_NC_1}:{_BB_NC_1_LOG};{_NC_3}:{_BB_NC_3_LOG}',
+        'logged_nc_code': f'{_NC_1};{_NC_3}',
+        'material': _MATERIAL,
+        'operation': _OPERATION,
+        'plant': _PLANT,
+        'predicted_annotation': f'{_NC_1}:{_BB_NC_1_PRED};{_NC_3}:{_BB_NC_3_PRED}',
+        'predicted_class': f'{_NC_1_CLASS}:0.95;{_NC_3_CLASS}:0.89',
+        'predicted_nc_code': f'{_NC_1}:0-95;{_NC_3}:0.89',
+        'resource': _RESOURCE,
+        'routing': _ROUTING,
+        'sfc': _SFC,
+        'source': _SOURCE
+    }, {
+        'file_id': _FILE_2,
+        'id': _TIME_2,
+        'type': _TYPE,
+        'view_name': _VIEW_NAME,
+        'material': _MATERIAL,
+        'operation': _OPERATION,
+        'plant': _PLANT,
+        'predicted_annotation': f'{_NC_2}:[]',
+        'predicted_class': f'{_NC_2_CLASS}:0.75',
+        'predicted_nc_code': f'{_NC_2}:0.75',
+        'resource': _RESOURCE,
+        'routing': _ROUTING,
+        'sfc': _SFC,
+        'source': _SOURCE
+    }, {
+        'file_id': _FILE_2,
+        'id': _TIME_3,
+        'type': _TYPE,
+        'view_name': _VIEW_NAME,
+        'material': _MATERIAL,
+        'operation': _OPERATION,
+        'plant': _PLANT,
+        'resource': _RESOURCE,
+        'routing': _ROUTING,
+        'sfc': _SFC,
+        'source': _SOURCE
+    }]
+
+    for i in range(3):
+        # the function find_inpection_logs does not return the dictionaries in the same order as the mock response, so
+        # matching them by their id is required
+        matching_dict = next((item for item in expected_attributes if item['id'] == getattr(inspection_logs[i], 'id')),
+                             None)
+        for property_name, value in matching_dict.items():
+            assert type(inspection_logs[i]) == InspectionLog
+            assert getattr(inspection_logs[i], property_name) == value
+
+
+def test_get_details(mock_url, mock_fetch):
+    kwargs = {
+        'scenario_id': '123',
+        'scenario_version': 1,
+    }
+
+    expected_url_context = 'base_url/aiml/v1/inspectionLogsForContext'
+
+    expected_url_log = 'base_url/aiml/v1/inspectionLog'
+
+    expected_filters_context = {
+        'scenario_id': '123',
+        'scenario_version': 1,
+    }
+
+    expected_filters_log = {
+        'id': _TIME_1,
+        'file_id': _FILE_1,
+        'plant': _PLANT,
+        'sfc': _SFC,
+        'material': _MATERIAL,
+        'operation': _OPERATION,
+    }
+
+    expected_filter_fields = {
+        'file_id': 'fileID',
+        'from_date': 'fromDate',
+        'to_date': 'toDate',
+        'inspection_view_name': 'inspectionViewName',
+        'logged_nc_code': 'loggedNCCode',
+        'material': 'material',
+        'operation': 'operation',
+        'plant': 'plant',
+        'resource': 'resource',
+        'routing': 'routing',
+        'scenario_id': 'scenarioID',
+        'scenario_version': 'scenarioVersion',
+        'sfc': 'sfc',
+        'skip': 'skip',
+        'source': 'source',
+        'top': 'top',
+        'id': 'inspectionLogTime',
+    }
+
+    mock_fetch.side_effect = [_MOCK_RESPONSE, _DETAILS_1]
+
+    inspection_logs = find_inspection_logs(**kwargs)
+
+    # the function find_inpection_logs does not return the dictionaries in the same order as the mock response, so
+    # matching them by their id is required
+    inspection_log = next(item for item in inspection_logs if getattr(item, 'id') == _TIME_1)
+
+    actual = inspection_log._get_details()
+
+    assert actual == _DETAILS_1
+
+    mock_fetch.assert_has_calls([
+        call(expected_url_context, expected_filters_context, expected_filter_fields),
+        call(expected_url_log, expected_filters_log, expected_filter_fields),
+    ])
+
+
+def test_get_details_and_images(mock_url, mock_fetch, mock_details):
+    kwargs = {
+        'scenario_id': '123',
+        'scenario_version': 1,
+    }
+
+    details_list = [_DETAILS_1.copy(), _DETAILS_2.copy(), _DETAILS_3.copy()]
+
+    file_1_decoded = b64decode(_FILE_1_CONTENT)
+    file_2_decoded = b64decode(_FILE_2_CONTENT)
+
+    mock_details.side_effect = details_list
+
+    inspection_logs = find_inspection_logs(**kwargs)
+
+    details, images = inspection_logs._get_details_and_images()
+
+    assert len(details) == 3
+    for i in range(len(details)):
+        assert details[i] == details_list[i]
+
+    assert len(images) == 2
+    assert images[_FILE_1] == file_1_decoded
+    assert images[_FILE_2] == file_2_decoded
+
+
+def test_as_ml_input(mock_url, mock_fetch, mock_details):
+    kwargs = {
+        'scenario_id': '123',
+        'scenario_version': 1,
+    }
+
+    details_list = [_DETAILS_1.copy(), _DETAILS_2.copy(), _DETAILS_3.copy()]
+
+    mock_details.side_effect = details_list
+
+    inspection_logs = find_inspection_logs(**kwargs)
+
+    df, images = inspection_logs.as_ml_input()
+
+    assert len(df) == 2
+    assert len(images) == 2
+
+    expected_columns = [
+        'fileContentType', 'fileId', 'inspectionLogTime', 'inspectionViewName', 'isConformant', 'loggedNCS', 'material',
+        'operation', 'plant', 'predictions', 'resource', 'routing', 'scenarioID', 'sfc', 'source'
+    ]
+
+    expected_timestamps = pd.to_datetime(pd.Series([_TIME_1, _TIME_3])).to_list()
+    unexpected_timestamps = pd.to_datetime(pd.Series([_TIME_2])).to_list()
+    actual_timestamps = df['inspectionLogTime'].to_list()
+
+    assert sorted(expected_columns) == sorted(df.columns.to_list())
+
+    assert sorted(expected_timestamps) == sorted(actual_timestamps)
+
+    for ts in unexpected_timestamps:
+        assert ts not in actual_timestamps
+
+    expected_images = {
+        _FILE_1: b64decode(_FILE_1_CONTENT),
+        _FILE_2: b64decode(_FILE_2_CONTENT),
+    }
+
+    assert images == expected_images
+
+
+def test_as_ml_input_with_duplicates(mock_url, mock_fetch, mock_details):
+    kwargs = {
+        'scenario_id': '123',
+        'scenario_version': 1,
+    }
+
+    details_list = [_DETAILS_1.copy(), _DETAILS_2.copy(), _DETAILS_3.copy()]
+
+    mock_details.side_effect = details_list
+
+    inspection_logs = find_inspection_logs(**kwargs)
+
+    df, images = inspection_logs.as_ml_input(remove_duplicates=False)
+
+    assert len(df) == 3
+    assert len(images) == 2
+
+    expected_columns = [
+        'fileContentType', 'fileId', 'inspectionLogTime', 'inspectionViewName', 'isConformant', 'loggedNCS', 'material',
+        'operation', 'plant', 'predictions', 'resource', 'routing', 'scenarioID', 'sfc', 'source'
+    ]
+
+    expected_timestamps = pd.to_datetime(pd.Series([_TIME_1, _TIME_2, _TIME_3])).to_list()
+    actual_timestamps = df['inspectionLogTime'].to_list()
+
+    assert sorted(expected_columns) == sorted(df.columns.to_list())
+
+    assert sorted(expected_timestamps) == sorted(actual_timestamps)
+
+
+def test_as_binary_classification_input(mock_url, mock_fetch, mock_details):
+    kwargs = {
+        'scenario_id': '123',
+        'scenario_version': 1,
+    }
+
+    details_list = [_DETAILS_1.copy(), _DETAILS_2.copy(), _DETAILS_3.copy()]
+
+    mock_details.side_effect = details_list
+
+    inspection_logs = find_inspection_logs(**kwargs)
+
+    df, images = inspection_logs.as_binary_classification_input()
+
+    assert len(df) == 2
+    assert len(images) == 2
+
+    expected_columns = [
+        'fileContentType', 'fileId', 'inspectionLogTime', 'inspectionViewName', 'isConformant', 'material', 'operation',
+        'plant', 'resource', 'routing', 'scenarioID', 'sfc', 'source'
+    ]
+
+    expected_timestamps = pd.to_datetime(pd.Series([_TIME_1, _TIME_3])).to_list()
+    unexpected_timestamps = pd.to_datetime(pd.Series([_TIME_2])).to_list()
+    actual_timestamps = df['inspectionLogTime'].to_list()
+
+    assert sorted(expected_columns) == sorted(df.columns.to_list())
+
+    assert sorted(expected_timestamps) == sorted(actual_timestamps)
+
+    for ts in unexpected_timestamps:
+        assert ts not in actual_timestamps
+
+    for index, row in df.iterrows():
+        assert row['isConformant'] in [True, False]
+
+
+def test_as_multilabel_classification_input(mock_url, mock_fetch, mock_details):
+    kwargs = {
+        'scenario_id': '123',
+        'scenario_version': 1,
+    }
+
+    details_list = [_DETAILS_1.copy(), _DETAILS_2.copy(), _DETAILS_3.copy()]
+
+    mock_details.side_effect = details_list
+
+    inspection_logs = find_inspection_logs(**kwargs)
+
+    df, images = inspection_logs.as_multilabel_classification_input()
+
+    assert len(df) == 2
+    assert len(images) == 2
+
+    expected_columns = [
+        'fileContentType', 'fileId', 'inspectionLogTime', 'inspectionViewName', 'isConformant', 'loggedNCS', 'material',
+        'operation', 'plant', 'predictions', 'resource', 'routing', 'scenarioID', 'sfc', 'source'
+    ]
+
+    expected_timestamps = pd.to_datetime(pd.Series([_TIME_1, _TIME_2])).to_list()
+    unexpected_timestamps = pd.to_datetime(pd.Series([_TIME_3])).to_list()
+    actual_timestamps = df['inspectionLogTime'].to_list()
+
+    assert sorted(expected_columns) == sorted(df.columns.to_list())
+
+    assert sorted(expected_timestamps) == sorted(actual_timestamps)
+
+    for ts in unexpected_timestamps:
+        assert ts not in actual_timestamps
+
+    for index, row in df.iterrows():
+        assert (row['predictions'] != '[]') or (row['loggedNCS'] != '[]')
+
+
+def _contains_bounding_box(row):
+    for prediction in row['predictions']:
+        if 'predictionBoundingBoxCoords' in prediction.keys():
+            if prediction['predictionBoundingBoxCoords'] != '[]':
+                return True
+
+    for logged_ncs in row['loggedNCS']:
+        if 'defectBoundingBoxCoords' in logged_ncs.keys():
+            if logged_ncs['defectBoundingBoxCoords'] != '[]':
+                return True
+
+    return False
+
+
+def test_as_object_detection_input(mock_url, mock_fetch, mock_details):
+    kwargs = {
+        'scenario_id': '123',
+        'scenario_version': 1,
+    }
+
+    details_list = [_DETAILS_1.copy(), _DETAILS_2.copy(), _DETAILS_3.copy()]
+
+    mock_details.side_effect = details_list
+
+    inspection_logs = find_inspection_logs(**kwargs)
+
+    df, images = inspection_logs.as_object_detection_input()
+
+    assert len(df) == 1
+    assert len(images) == 1
+
+    expected_columns = [
+        'fileContentType', 'fileId', 'inspectionLogTime', 'inspectionViewName', 'isConformant', 'loggedNCS', 'material',
+        'operation', 'plant', 'predictions', 'resource', 'routing', 'scenarioID', 'sfc', 'source'
+    ]
+
+    expected_timestamps = pd.to_datetime(pd.Series([_TIME_1])).to_list()
+    unexpected_timestamps = pd.to_datetime(pd.Series([_TIME_2, _TIME_3])).to_list()
+    actual_timestamps = df['inspectionLogTime'].to_list()
+
+    assert sorted(expected_columns) == sorted(df.columns.to_list())
+
+    assert sorted(expected_timestamps) == sorted(actual_timestamps)
+
+    for ts in unexpected_timestamps:
+        assert ts not in actual_timestamps
+
+    expected_images = {
+        _FILE_1: b64decode(_FILE_1_CONTENT),
+    }
+
+    assert images == expected_images
+
+    for index, row in df.iterrows():
+        assert (row['predictions'] != '[]') or (row['loggedNCS'] != '[]')
+        assert _contains_bounding_box(row)

--- a/tests/test_sailor/test_dmc/test_scenario.py
+++ b/tests/test_sailor/test_dmc/test_scenario.py
@@ -1,0 +1,99 @@
+from unittest.mock import patch
+
+import pytest
+from sailor.dmc.scenario import Scenario, ScenarioSet, find_scenarios
+
+
+@pytest.fixture
+def mock_url():
+    with patch('sailor.dmc.scenario._dmc_application_url') as mock:
+        mock.return_value = 'base_url'
+        yield mock
+
+
+@pytest.fixture
+def mock_fetch():
+    with patch('sailor.dmc.scenario._dmc_fetch_data') as mock:
+        mock.return_value = [{
+            'scenarioCreatedAt': '2000-01-01 00:00:00.000',
+            'scenarioChangedAt': '2000-01-02 00:00:00.000',
+            'scenarioDescription': 'Example_Description',
+            'scenarioId': 'Example_ID',
+            'scenarioName': 'Example_Name',
+            'scenarioObjective': 'Example_Objective',
+            'scenarioStatus': 'Example_Status',
+            'scenarioVersion': 1
+        }]
+        yield mock
+
+
+def test_expected_public_attributes_are_present():
+    expected_attributes = [
+        'short_description', 'id', 'name', 'objective', 'status', 'version', 'created_at', 'changed_at'
+    ]
+
+    fieldmap_public_attributes = [field.our_name for field in Scenario._field_map.values() if field.is_exposed]
+
+    assert expected_attributes == fieldmap_public_attributes
+
+
+def test_correct_arguments(mock_url, mock_fetch):
+
+    plant = 'Example_Plant'
+    sfc = 'Example_SFC'
+
+    expected_url = 'base_url/aiml/v1/active-scenarios'
+
+    expected_filters = {
+        'plant': 'Example_Plant',
+        'sfc': 'Example_SFC',
+    }
+
+    expected_filter_fields = {
+        'deployment_type': 'deploymentType',
+        'material': 'material',
+        'operation': 'operation',
+        'plant': 'plant',
+        'resource': 'resource',
+        'routing': 'routing',
+        'sfc': 'sfc',
+    }
+
+    find_scenarios(plant=plant, sfc=sfc)
+
+    mock_fetch.assert_called_once_with(expected_url, expected_filters, expected_filter_fields)
+
+
+def test_correct_scenario_object(mock_url, mock_fetch):
+    kwargs = {
+        'deployment_type': 'Deployment_Type',
+        'material': 'Example_Material',
+        'operation': 'Example_Operation',
+        'plant': 'Example_Plant',
+        'resource': 'Example_Resource',
+        'routing': 'Example_Routing',
+        'sfc': 'Example_SFC',
+    }
+
+    scenarios = find_scenarios(**kwargs)
+
+    assert len(scenarios) == 1
+    assert type(scenarios) == ScenarioSet
+
+    scenario = scenarios[0]
+
+    assert type(scenario) == Scenario
+
+    expected_attributes = {
+        'id': 'Example_ID',
+        'version': 1,
+        'name': 'Example_Name',
+        'objective': 'Example_Objective',
+        'status': 'Example_Status',
+        'short_description': 'Example_Description',
+        'created_at': '2000-01-01 00:00:00.000',
+        'changed_at': '2000-01-02 00:00:00.000',
+    }
+
+    for property_name, value in expected_attributes.items():
+        assert getattr(scenario, property_name) == value

--- a/tests/test_sailor/test_dmc/test_utils.py
+++ b/tests/test_sailor/test_dmc/test_utils.py
@@ -1,0 +1,79 @@
+import pytest
+from sailor.dmc.utils import _dmc_fetch_data
+from sailor.utils.utils import DataNotFoundWarning
+
+
+def test_dmc_fetch_data_expected_filter_processing(mock_request):
+    filters = {
+        'scenario_id': '123',
+        'scenario_version': 1,
+        'plant': 'Example_Plant',
+        'expected_parameter': 'Expected_Value',
+    }
+    filter_fields = {
+        'scenario_id': 'scenarioID',
+        'scenario_version': 'scenarioVersion',
+        'plant': 'plant',
+        'expected_parameter': 'expectedParameter',
+    }
+    expected_parameters = {
+        'scenarioID': '123',
+        'scenarioVersion': '1',
+        'plant': 'Example_Plant',
+        'expectedParameter': 'Expected_Value',
+    }
+    expected = mock_request.return_value = ['expected_result']
+
+    with pytest.warns(None) as record:
+        actual = _dmc_fetch_data('', filters, filter_fields)
+
+    mock_request.assert_called_once_with('GET', '', params=expected_parameters)
+    assert expected == actual
+    assert len(record) == 0
+
+
+def test_dmc_fetch_data_unknown_filter_processing(mock_request):
+    filters = {
+        'scenario_id': '123',
+        'scenario_version': 1,
+        'plant': 'Example_Plant',
+        'expected_parameter': 'Expected_Value',
+        'unexpected_parameter': 'Unexpected_Value',
+    }
+    filter_fields = {
+        'scenario_id': 'scenarioID',
+        'scenario_version': 'scenarioVersion',
+        'plant': 'plant',
+        'expected_parameter': 'expectedParameter',
+    }
+    expected_parameters = {
+        'scenarioID': '123',
+        'scenarioVersion': '1',
+        'plant': 'Example_Plant',
+        'expectedParameter': 'Expected_Value',
+        'unexpected_parameter': 'Unexpected_Value',
+    }
+    expected = mock_request.return_value = ['expected_result']
+
+    with pytest.warns(UserWarning,
+                      match=r'^Following parameters are not in our terminology: \[\'unexpected_parameter\'\]$'):
+        actual = _dmc_fetch_data('', filters, filter_fields)
+
+    mock_request.assert_called_once_with('GET', '', params=expected_parameters)
+    assert expected == actual
+
+
+def test_dmc_fetch_data_raises_warning_for_empty_result(mock_request):
+    filters = {
+        'scenario_id': '123',
+        'scenario_version': 1,
+    }
+    filter_fields = {
+        'scenario_id': 'scenarioID',
+        'scenario_version': 'scenarioVersion',
+    }
+
+    mock_request.return_value = []
+
+    with pytest.warns(DataNotFoundWarning, match='No data found for given parameters.'):
+        _dmc_fetch_data('', filters, filter_fields)


### PR DESCRIPTION
Supports retrieval of active scenarios and inspection logs from the DMC AIML API. Allows export of InspectionLogSets as DataFrames usable for general ML, binary classification, multilabel classification and object detection based on available information along with dictionaries containing the file content mapped to the file id.

# Description

Supported the following use case for the DMC API:
1.	Search for Active Scenario
2.	Get Analytical Data Set (Inspection Logs) from a Scenario
3.	Get Images and Inspection results from 
a.	as_ml_input(), 
b.	as_binary_classification_input()
c.	as_multilabel_classification_input()
d.	as_object_detection_input()

# Checklist

Mark "not applicable" if item on the list does not apply to this pull request.

- [x] I have created/adapted unit tests for new code
  - [ ] not applicable 
- [ ] I have added new dependencies as described at the [Contributing](https://sap.github.io/project-sailor/contributing.html#requirements-management) page
  - [x] not applicable 
- [ ] I have made corresponding changes to the documentation (incl. tutorial, etc.)
  - [x] not applicable 
- [ ] I have provided release notes (in description or as comment) if this PR is a new feature OR a change worth mentioning for next release
  - [x] not applicable 
- [x] I have obtained API approvals if a new SAP API or endpoint is used
  - [ ] not applicable 
