### PR TITLE
Fix failing test on windows machines

### DIFF
--- a/tests/test_sailor/test_utils/test_oauth_flow.py
+++ b/tests/test_sailor/test_utils/test_oauth_flow.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from unittest.mock import patch, MagicMock
-from datetime import datetime
 
 from rauth import OAuth2Session
 import jwt
@@ -158,7 +157,7 @@ def test_scopes_config_available_decoding_token_fails(jwt_decode_mock):
     mock_method.assert_called_once()
 
 
-@patch('jwt.decode', return_value={'exp': datetime(9999, 12, 31).timestamp()})
+@patch('jwt.decode', return_value={'exp': 253402210800})
 @patch('rauth.OAuth2Service.get_auth_session')
 def test_get_session_returns_active_session_on_repeated_calls(get_auth_mock, decode_mock):
     expected_session = MagicMock()
@@ -172,8 +171,7 @@ def test_get_session_returns_active_session_on_repeated_calls(get_auth_mock, dec
     assert actual == expected_session
 
 
-@patch('jwt.decode', return_value={'exp': datetime(9999, 12, 31).timestamp(),
-                                   'scope': ['test']})
+@patch('jwt.decode', return_value={'exp': 253402210800, 'scope': ['test']})
 @patch('rauth.OAuth2Service.get_auth_session')
 def test_get_session_returns_new_session_if_scopes_are_different(get_auth_mock, decode_mock):
     new_scopes_requested = 'abc def'


### PR DESCRIPTION
# Description

Calling datetime for the year 9999 on windows results in an OSError.
Let's just take a good old number.

# Checklist

Mark "not applicable" if item on the list does not apply to this pull request.

- [ ] I have created/adapted unit tests for new code
  - [x] not applicable 
- [ ] I have added new dependencies as described at the [Contributing](https://sap.github.io/project-sailor/contributing.html#requirements-management) page
  - [x] not applicable 
- [ ] I have made corresponding changes to the documentation (incl. tutorial, etc.)
  - [x] not applicable 
- [ ] I have provided release notes (in description or as comment) if this PR is a new feature OR a change worth mentioning for next release
  - [x] not applicable 
- [ ] I have obtained API approvals if a new SAP API or endpoint is used
  - [x] not applicable 
