### PR TITLE
Fix/ac rate limiting

### DIFF
--- a/tests/test_sailor/test_assetcentral/test_utils.py
+++ b/tests/test_sailor/test_assetcentral/test_utils.py
@@ -1,5 +1,6 @@
 import pytest
 
+from sailor.utils.oauth_wrapper import RequestError
 from sailor.assetcentral.utils import (
     AssetcentralRequestValidationError, _AssetcentralField, _AssetcentralWriteRequest, AssetcentralEntity,
     _ac_fetch_data, _ac_response_handler)
@@ -111,3 +112,33 @@ def test_ac_fetch_data_integration(mock_request):
 
     mock_request.assert_called_once_with('GET', '', params=expected_parameters)
     assert actual == expected
+
+
+def test_ac_fetch_data_rate_limiting(mock_request):
+    exception = RequestError('test_message', 429, 'reason', 'error_text')
+    mock_request.side_effect = [exception, 'retry-response']
+
+    actual = _ac_fetch_data('')
+
+    assert mock_request.call_count == 2
+    assert actual == ['retry-response']
+
+
+def test_ac_fetch_data_rate_limiting_repeated_error(mock_request):
+    exception = RequestError('test_message', 429, 'reason', 'error_text')
+    mock_request.side_effect = [exception, exception, 'some-response']
+
+    with pytest.raises(RequestError, match='test_message'):
+        _ac_fetch_data('')
+
+    assert mock_request.call_count == 2
+
+
+def test_ac_fetch_data_rate_limiting_different_exception(mock_request):
+    exception = RuntimeError('Unexpected Error')
+    mock_request.side_effect = [exception, 'some-response']
+
+    with pytest.raises(RuntimeError, match='Unexpected Error'):
+        _ac_fetch_data('')
+
+    assert mock_request.call_count == 1


### PR DESCRIPTION
# Description

AC seems to have introduced rate limiting, unfortunately without the usual retry-after return header. This works around the rate limiting, right now just waiting for 1s fix.

# Additional information

The three added tests run 1s each due to the `sleep`, not sure if we should try to mock that out?

# Checklist

Mark "not applicable" if item on the list does not apply to this pull request.

- [x] I have created/adapted unit tests for new code
  - [ ] not applicable 
- [ ] I have added new dependencies as described at the [Contributing](https://sap.github.io/project-sailor/contributing.html#requirements-management) page
  - [x] not applicable 
- [ ] I have made corresponding changes to the documentation (incl. tutorial, etc.)
  - [x] not applicable 
- [ ] I have provided release notes (in description or as comment) if this PR is a new feature OR a change worth mentioning for next release
  - [x] not applicable 
- [ ] I have obtained API approvals if a new SAP API or endpoint is used
  - [x] not applicable 
