### PR TITLE
add workaround for empty csv files in iot response

### DIFF
--- a/sailor/sap_iot/fetch.py
+++ b/sailor/sap_iot/fetch.py
@@ -82,10 +82,16 @@ def _process_one_file(ifile: BinaryIO, indicator_set: IndicatorSet, equipment_se
     selected_equipment_ids = [equipment.id for equipment in equipment_set]  # noqa: F841
     dtypes = {indicator._liot_id: float for indicator in indicator_set if indicator.datatype in float_types}
     dtypes.update({'equipmentId': 'object', 'indicatorGroupId': 'object', 'templateId': 'object'})
-    df = pd.read_csv(ifile,
-                     usecols=lambda x: x != 'modelId',
-                     parse_dates=['_TIME'], date_parser=partial(pd.to_datetime, utc=True, unit='ms', errors='coerce'),
-                     dtype=dtypes)
+
+    try:
+        df = pd.read_csv(ifile,
+                         usecols=lambda x: x != 'modelId',
+                         parse_dates=['_TIME'],
+                         date_parser=partial(pd.to_datetime, utc=True, unit='ms', errors='coerce'),
+                         dtype=dtypes)
+    except pd.errors.EmptyDataError:
+        LOG.debug('Empty file returned by SAP IoT API, ignoring the file.')
+        return pd.DataFrame()
 
     df = df.pivot(index=['_TIME', 'equipmentId'], columns=['indicatorGroupId', 'templateId'])
 

--- a/tests/test_sailor/conftest.py
+++ b/tests/test_sailor/conftest.py
@@ -1,4 +1,5 @@
 from unittest.mock import patch
+from collections import defaultdict
 
 import pytest
 
@@ -9,6 +10,7 @@ from sailor.assetcentral.equipment import Equipment, EquipmentSet
 @pytest.fixture()
 def mock_config():
     with patch('sailor.utils.config.SailorConfig') as mock:
+        mock.config.sap_iot = defaultdict(str, export_url='EXPORT_URL', download_url='DOWNLOAD_URL')
         yield mock
 
 


### PR DESCRIPTION
# Description

It looks like SAP IoT can return entirely empty files under some circumstances, which pandas will not parse. This is adding a workaround.

# Checklist

Mark "not applicable" if item on the list does not apply to this pull request.

- [x] I have created/adapted unit tests for new code
  - [ ] not applicable 
- [ ] I have added new dependencies as described at the [Contributing](https://sap.github.io/project-sailor/contributing.html#requirements-management) page
  - [x] not applicable 
- [ ] I have made corresponding changes to the documentation (incl. tutorial, etc.)
  - [x] not applicable 
- [ ] I have provided release notes (in description or as comment) if this PR is a new feature OR a change worth mentioning for next release
  - [x] not applicable 
- [ ] I have obtained API approvals if a new SAP API or endpoint is used
  - [x] not applicable 
