### PR TITLE
Pytest: compatible with ver 7 / DeprecationWarnings don't error warnings

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ add-ignore = D104,D404
 # unexpected warnings must be fixed. if not possible immediately, add to the list below.
 filterwarnings = default
     error::Warning
+    once::DeprecationWarning
 
 
 [coverage:run]

--- a/tests/test_sailor/test_utils/test_timestamps.py
+++ b/tests/test_sailor/test_utils/test_timestamps.py
@@ -1,4 +1,5 @@
 import datetime
+import warnings
 
 import pytest
 import pandas as pd
@@ -47,8 +48,8 @@ def test_timestamp_to_date_string(input, expected, expect_warning, testdescr):
         with pytest.warns(UserWarning):
             actual = _timestamp_to_date_string(input)
     else:
-        with pytest.warns(None) as record:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
             actual = _timestamp_to_date_string(input)
-            if len(record) > 0:
-                pytest.fail('Did not expect a warning.')
+
     assert actual == expected


### PR DESCRIPTION
Pytest 7 has deprecated the warnings capture for pytest.warns(None).
We could add their deprecation warning to the ignore list but the forward fix is easy.

Also exlcude DeprecationsWarnings from erroring tests that emit warnings

# Additional information

New info from pytest how to capture (non-)warnings:
```
E           pytest.PytestRemovedIn8Warning: Passing None has been deprecated.
E           See https://docs.pytest.org/en/latest/how-to/capture-warnings.html#additional-use-cases-of-warnings-in-tests for alternatives in common use cases.
```
![Screen Shot 2022-02-08 at 12 10 39](https://user-images.githubusercontent.com/1148588/152975693-d3c7c9bc-9edb-4c52-917f-07f8c620abbb.png)

# Checklist

Mark "not applicable" if item on the list does not apply to this pull request.

- [ ] I have created/adapted unit tests for new code
  - [x] not applicable 
- [ ] I have added new dependencies as described at the [Contributing](https://sap.github.io/project-sailor/contributing.html#requirements-management) page
  - [x] not applicable 
- [ ] I have made corresponding changes to the documentation (incl. tutorial, etc.)
  - [x] not applicable 
- [ ] I have provided release notes (in description or as comment) if this PR is a new feature OR a change worth mentioning for next release
  - [x] not applicable 
- [ ] I have obtained API approvals if a new SAP API or endpoint is used
  - [x] not applicable 
