### PR TITLE
fix a bug in _compose_queries

### DIFF
--- a/sailor/_base/fetch.py
+++ b/sailor/_base/fetch.py
@@ -205,7 +205,7 @@ def _compose_queries(unbreakable_filters, breakable_filters):
                 # this one is too long, but also the last element
                 # since we had to break, we have to add the last element separately
                 if end_idx == len(filter_group):
-                    result.extend(q + ' and ' + filter_group[-1] for q in filters)
+                    result.extend(q + ' and ' + filter_group[-1] if q != '' else filter_group[-1] for q in filters)
                     break
                 else:
                     start_idx = end_idx - 1
@@ -218,7 +218,6 @@ def _compose_queries(unbreakable_filters, breakable_filters):
             end_idx += 1
 
         filters = result
-
     return filters
 
 

--- a/tests/test_sailor/test__base/test_fetch.py
+++ b/tests/test_sailor/test__base/test_fetch.py
@@ -398,6 +398,22 @@ class TestComposeQueries:
             for item in sublist:
                 assert item in big_filter_string
 
+    def test_compose_queries_many_filters_break_by_one(self):
+        # for this test _compose_queries field name and field_values
+        # must be chosen such that exactly two queries result, and the
+        # second one gets just *one* entry. This assumes max_filter_length
+        # in _compose_queries is 2000
+
+        field_value = '144B9A523FB54D00B574365605C6E343'
+        field_values = [field_value] * 36
+        filters = parse_filter_parameters({'query_field_name': field_values})
+        queries = _compose_queries(*filters)
+
+        assert len(queries) == 2
+        assert queries[0].count(field_value) == 35
+        assert queries[1].count(field_value) == 1
+        assert not queries[1].startswith(' and ')
+
 
 class TestFetchData:
 

--- a/tests/test_sailor/test__base/test_fetch.py
+++ b/tests/test_sailor/test__base/test_fetch.py
@@ -398,6 +398,7 @@ class TestComposeQueries:
             for item in sublist:
                 assert item in big_filter_string
 
+    @pytest.mark.filterwarnings('ignore:Following parameters are not in our terminology')
     def test_compose_queries_many_filters_break_by_one(self):
         # for this test _compose_queries field name and field_values
         # must be chosen such that exactly two queries result, and the


### PR DESCRIPTION
# Description

This fixes a bug in _compose_queries that only occurs if there is exactly one filter that needs to move to a new request group.

Fixes jira: DS2020-414

# Checklist

Mark "not applicable" if item on the list does not apply to this pull request.

- [x] I have created/adapted unit tests for new code
  - [ ] not applicable 
- [ ] I have added new dependencies as described at the [Contributing](https://sap.github.io/project-sailor/contributing.html#requirements-management) page
  - [x] not applicable 
- [ ] I have made corresponding changes to the documentation (incl. tutorial, etc.)
  - [x] not applicable 
- [ ] I have provided release notes (in description or as comment) if this PR is a new feature OR a change worth mentioning for next release
  - [x] not applicable 
- [ ] I have obtained API approvals if a new SAP API or endpoint is used
  - [x] not applicable 
