### PR TITLE
Add timeout parameter for data export

### DIFF
--- a/sailor/assetcentral/equipment.py
+++ b/sailor/assetcentral/equipment.py
@@ -80,8 +80,6 @@ _EQUIPMENT_FIELDS = [
     _AssetcentralField('_class', 'class'),
 ]
 
-timeout_seconds = sap_iot.fetch.GET_INDICATOR_DATA_TIMELIMIT_SECONDS
-
 
 @_base.add_properties
 class Equipment(AssetcentralEntity):
@@ -205,8 +203,7 @@ class Equipment(AssetcentralEntity):
     def get_indicator_data(self, start: Union[str, pd.Timestamp, datetime.timestamp, datetime.date],
                            end: Union[str, pd.Timestamp, datetime.timestamp, datetime.date],
                            indicator_set: IndicatorSet = None,
-                           timeout: Union[str, pd.Timedelta, datetime.timedelta] = timeout_seconds
-                           ) -> TimeseriesDataset:
+                           timeout: Union[str, pd.Timedelta, datetime.timedelta] = None) -> TimeseriesDataset:
         """
         Fetch timeseries data from SAP Internet of Things for Indicators attached to this equipment.
 
@@ -372,8 +369,7 @@ class EquipmentSet(AssetcentralEntitySet):
     def get_indicator_data(self, start: Union[str, pd.Timestamp, datetime.timestamp, datetime.date],
                            end: Union[str, pd.Timestamp, datetime.timestamp, datetime.date],
                            indicator_set: IndicatorSet = None,
-                           timeout: Union[str, pd.Timedelta, datetime.timedelta] = timeout_seconds
-                           ) -> TimeseriesDataset:
+                           timeout: Union[str, pd.Timedelta, datetime.timedelta] = None) -> TimeseriesDataset:
         """
         Fetch timeseries data from SAP Internet of Things for Indicators attached to all equipments in this set.
 

--- a/sailor/assetcentral/equipment.py
+++ b/sailor/assetcentral/equipment.py
@@ -80,6 +80,8 @@ _EQUIPMENT_FIELDS = [
     _AssetcentralField('_class', 'class'),
 ]
 
+timeout_seconds = sap_iot.fetch.GET_INDICATOR_DATA_TIMELIMIT_SECONDS
+
 
 @_base.add_properties
 class Equipment(AssetcentralEntity):
@@ -202,7 +204,9 @@ class Equipment(AssetcentralEntity):
 
     def get_indicator_data(self, start: Union[str, pd.Timestamp, datetime.timestamp, datetime.date],
                            end: Union[str, pd.Timestamp, datetime.timestamp, datetime.date],
-                           indicator_set: IndicatorSet = None) -> TimeseriesDataset:
+                           indicator_set: IndicatorSet = None,
+                           timeout: Union[str, pd.Timedelta, datetime.timedelta] = timeout_seconds
+                           ) -> TimeseriesDataset:
         """
         Fetch timeseries data from SAP Internet of Things for Indicators attached to this equipment.
 
@@ -218,6 +222,10 @@ class Equipment(AssetcentralEntity):
             Date of end of requested timeseries data. Any time component will be ignored
         indicator_set
             IndicatorSet for which timeseries data is returned.
+        timeout
+            Maximum amount of time the request may take. Can be specified as an ISO 8601 string
+            (like `PT2M` for 2-minute duration) or as a pandas.Timedelta or datetime.timedelta object.
+            If None, there is no time limit.
 
         Example
         -------
@@ -232,7 +240,7 @@ class Equipment(AssetcentralEntity):
         if indicator_set is None:
             indicator_set = self.find_equipment_indicators()
 
-        return sap_iot.get_indicator_data(start, end, indicator_set, EquipmentSet([self]))
+        return sap_iot.get_indicator_data(start, end, indicator_set, EquipmentSet([self]), timeout)
 
     def create_notification(self, **kwargs) -> Notification:
         """Create a new notification for this equipment.
@@ -363,7 +371,9 @@ class EquipmentSet(AssetcentralEntitySet):
 
     def get_indicator_data(self, start: Union[str, pd.Timestamp, datetime.timestamp, datetime.date],
                            end: Union[str, pd.Timestamp, datetime.timestamp, datetime.date],
-                           indicator_set: IndicatorSet = None) -> TimeseriesDataset:
+                           indicator_set: IndicatorSet = None,
+                           timeout: Union[str, pd.Timedelta, datetime.timedelta] = timeout_seconds
+                           ) -> TimeseriesDataset:
         """
         Fetch timeseries data from SAP Internet of Things for Indicators attached to all equipments in this set.
 
@@ -378,6 +388,10 @@ class EquipmentSet(AssetcentralEntitySet):
             Date of end of requested timeseries data. Any time component will be ignored.
         indicator_set
             IndicatorSet for which timeseries data is returned.
+        timeout
+            Maximum amount of time the request may take. Can be specified as an ISO 8601 string
+            (like `PT2M` for 2-minute duration) or as a pandas.Timedelta or datetime.timedelta object.
+            If None, there is no time limit.
 
         Example
         -------
@@ -393,7 +407,7 @@ class EquipmentSet(AssetcentralEntitySet):
         if indicator_set is None:
             indicator_set = self.find_common_indicators()
 
-        return sap_iot.get_indicator_data(start, end, indicator_set, self)
+        return sap_iot.get_indicator_data(start, end, indicator_set, self, timeout)
 
     def get_indicator_aggregates(
             self, start: Union[str, pd.Timestamp, datetime.timestamp, datetime.date],

--- a/sailor/assetcentral/system.py
+++ b/sailor/assetcentral/system.py
@@ -57,8 +57,6 @@ _SYSTEM_FIELDS = [
     _AssetcentralField('_completeness', 'completeness'),
 ]
 
-timeout_seconds = sap_iot.fetch.GET_INDICATOR_DATA_TIMELIMIT_SECONDS
-
 
 @_base.add_properties
 class System(AssetcentralEntity):
@@ -149,8 +147,7 @@ class System(AssetcentralEntity):
 
     def get_indicator_data(self, start: Union[str, pd.Timestamp, datetime.timestamp, datetime.date],
                            end: Union[str, pd.Timestamp, datetime.timestamp, datetime.date],
-                           timeout: Union[str, pd.Timedelta, datetime.timedelta] = timeout_seconds
-                           ) -> TimeseriesDataset:
+                           timeout: Union[str, pd.Timedelta, datetime.timedelta] = None) -> TimeseriesDataset:
         """
         Get timeseries data for all Equipment in the System.
 
@@ -189,8 +186,7 @@ class SystemSet(AssetcentralEntitySet):
 
     def get_indicator_data(self, start: Union[str, pd.Timestamp, datetime.timestamp, datetime.date],
                            end: Union[str, pd.Timestamp, datetime.timestamp, datetime.date],
-                           timeout: Union[str, pd.Timedelta, datetime.timedelta] = timeout_seconds
-                           ) -> TimeseriesDataset:
+                           timeout: Union[str, pd.Timedelta, datetime.timedelta] = None) -> TimeseriesDataset:
         """
         Fetch data for a set of systems for all component equipment of each system.
 

--- a/sailor/assetcentral/system.py
+++ b/sailor/assetcentral/system.py
@@ -177,7 +177,7 @@ class System(AssetcentralEntity):
         """
         all_indicators = sum((equi.find_equipment_indicators() for equi in self._hierarchy['equipment']),
                              IndicatorSet([]))
-        
+
         LOG.debug('Requesting indicator data of system "%s" for %d indicators.', self.id, len(all_indicators))
         return sap_iot.get_indicator_data(start, end, all_indicators, self._hierarchy['equipment'], timeout)
 

--- a/sailor/sap_iot/fetch.py
+++ b/sailor/sap_iot/fetch.py
@@ -247,7 +247,7 @@ def get_indicator_data(start_date: Union[str, pd.Timestamp, datetime.timestamp, 
             print('.', end='')
 
         if timeout is not None and timeout < (time.monotonic() - start_time):
-            raise RuntimeError(f'Timeout of {timeout:.0f} seconds was reached for fetching indicator data.')
+            raise TimeoutError(f'Timeout of {timeout:.0f} seconds was reached for fetching indicator data.')
     print()
 
     wrapper = TimeseriesDataset(results, indicator_set, equipment_set, start_date, end_date)

--- a/sailor/sap_iot/fetch.py
+++ b/sailor/sap_iot/fetch.py
@@ -35,7 +35,6 @@ LOG = logging.getLogger(__name__)
 LOG.addHandler(logging.NullHandler())
 LOG = WarningAdapter(LOG)
 
-GET_INDICATOR_DATA_TIMELIMIT_SECONDS = None
 
 fixed_timeseries_columns = {
     '_TIME': 'timestamp',
@@ -152,8 +151,7 @@ def _get_exported_bulk_timeseries_data(export_id: str,
 def get_indicator_data(start_date: Union[str, pd.Timestamp, datetime.timestamp, datetime.date],
                        end_date: Union[str, pd.Timestamp, datetime.timestamp, datetime.date],
                        indicator_set: IndicatorSet, equipment_set: EquipmentSet,
-                       timeout: Union[str, pd.Timedelta, datetime.timedelta] = GET_INDICATOR_DATA_TIMELIMIT_SECONDS
-                       ) -> TimeseriesDataset:
+                       timeout: Union[str, pd.Timedelta, datetime.timedelta] = None) -> TimeseriesDataset:
     """
     Read indicator data for a certain time period, a set of equipments and a set of indicators.
 

--- a/sailor/sap_iot/fetch.py
+++ b/sailor/sap_iot/fetch.py
@@ -247,8 +247,7 @@ def get_indicator_data(start_date: Union[str, pd.Timestamp, datetime.timestamp, 
             print('.', end='')
 
         if timeout is not None and timeout < (time.monotonic() - start_time):
-            LOG.debug('Timeout of %d seconds was reached for fetching indicator data.', timeout)
-            break
+            raise RuntimeError(f'Timeout of {timeout:.0f} seconds was reached for fetching indicator data.')
     print()
 
     wrapper = TimeseriesDataset(results, indicator_set, equipment_set, start_date, end_date)

--- a/sailor/sap_iot/fetch.py
+++ b/sailor/sap_iot/fetch.py
@@ -225,7 +225,7 @@ def get_indicator_data(start_date: Union[str, pd.Timestamp, datetime.timestamp, 
     results = pd.DataFrame(columns=schema.keys()).astype(schema)
 
     print('Waiting for data export:')
-    start_time = time.time()
+    start_time = time.monotonic()
     while request_ids:
         for request_id in list(request_ids):
             if _check_bulk_timeseries_export_status(request_id):
@@ -246,7 +246,7 @@ def get_indicator_data(start_date: Union[str, pd.Timestamp, datetime.timestamp, 
             time.sleep(5)
             print('.', end='')
 
-        if timeout is not None and timeout < (time.time() - start_time):
+        if timeout is not None and timeout < (time.monotonic() - start_time):
             LOG.debug('Timeout of %d seconds was reached for fetching indicator data.', timeout)
             break
     print()

--- a/sailor/sap_iot/fetch.py
+++ b/sailor/sap_iot/fetch.py
@@ -248,8 +248,8 @@ def get_indicator_data(start_date: Union[str, pd.Timestamp, datetime.timestamp, 
             time.sleep(5)
             print('.', end='')
 
-        if timeout is not None and timeout > (time.time() - start_time):
-            LOG.debug("Timeout of '%s' seconds was reached for fetching indicator data.", timeout)
+        if timeout is not None and timeout < (time.time() - start_time):
+            LOG.debug('Timeout of %d seconds was reached for fetching indicator data.', timeout)
             break
     print()
 

--- a/sailor/sap_iot/fetch.py
+++ b/sailor/sap_iot/fetch.py
@@ -152,7 +152,8 @@ def _get_exported_bulk_timeseries_data(export_id: str,
 def get_indicator_data(start_date: Union[str, pd.Timestamp, datetime.timestamp, datetime.date],
                        end_date: Union[str, pd.Timestamp, datetime.timestamp, datetime.date],
                        indicator_set: IndicatorSet, equipment_set: EquipmentSet,
-                       timeout: Union[str, pd.Timedelta, datetime.timedelta]) -> TimeseriesDataset:
+                       timeout: Union[str, pd.Timedelta, datetime.timedelta] = GET_INDICATOR_DATA_TIMELIMIT_SECONDS
+                       ) -> TimeseriesDataset:
     """
     Read indicator data for a certain time period, a set of equipments and a set of indicators.
 

--- a/sailor/sap_iot/fetch.py
+++ b/sailor/sap_iot/fetch.py
@@ -22,7 +22,7 @@ import pandas as pd
 
 import sailor.assetcentral.indicators as ac_indicators
 from sailor.utils.oauth_wrapper import get_oauth_client, RequestError
-from sailor.utils.timestamps import _any_to_timestamp, _timestamp_to_date_string
+from sailor.utils.timestamps import _any_to_timestamp, _timestamp_to_date_string, _any_to_timedelta
 from sailor.utils.config import SailorConfig
 from sailor.utils.utils import DataNotFoundWarning, WarningAdapter
 from .wrappers import TimeseriesDataset
@@ -34,6 +34,8 @@ if TYPE_CHECKING:
 LOG = logging.getLogger(__name__)
 LOG.addHandler(logging.NullHandler())
 LOG = WarningAdapter(LOG)
+
+GET_INDICATOR_DATA_TIMELIMIT_SECONDS = None
 
 fixed_timeseries_columns = {
     '_TIME': 'timestamp',
@@ -149,7 +151,8 @@ def _get_exported_bulk_timeseries_data(export_id: str,
 
 def get_indicator_data(start_date: Union[str, pd.Timestamp, datetime.timestamp, datetime.date],
                        end_date: Union[str, pd.Timestamp, datetime.timestamp, datetime.date],
-                       indicator_set: IndicatorSet, equipment_set: EquipmentSet) -> TimeseriesDataset:
+                       indicator_set: IndicatorSet, equipment_set: EquipmentSet,
+                       timeout: Union[str, pd.Timedelta, datetime.timedelta]) -> TimeseriesDataset:
     """
     Read indicator data for a certain time period, a set of equipments and a set of indicators.
 
@@ -163,6 +166,8 @@ def get_indicator_data(start_date: Union[str, pd.Timestamp, datetime.timestamp, 
         IndicatorSet for which timeseries data is returned.
     equipment_set:
         Equipment set for which the timeseries data is read.
+    timeout:
+        Maximum amount of time the request may take. If None there is no time limit.
 
     Example
     -------
@@ -177,6 +182,10 @@ def get_indicator_data(start_date: Union[str, pd.Timestamp, datetime.timestamp, 
     # as well as individual equipment in `_process_one_file`.
     if start_date is None or end_date is None:
         raise ValueError("Time parameters must be specified")
+
+    if timeout is not None:
+        timeout = _any_to_timedelta(timeout)
+        timeout = timeout.total_seconds()
 
     start_date = _any_to_timestamp(start_date)
     end_date = _any_to_timestamp(end_date)
@@ -217,6 +226,7 @@ def get_indicator_data(start_date: Union[str, pd.Timestamp, datetime.timestamp, 
     results = pd.DataFrame(columns=schema.keys()).astype(schema)
 
     print('Waiting for data export:')
+    start_time = time.time()
     while request_ids:
         for request_id in list(request_ids):
             if _check_bulk_timeseries_export_status(request_id):
@@ -236,6 +246,10 @@ def get_indicator_data(start_date: Union[str, pd.Timestamp, datetime.timestamp, 
         if request_ids:
             time.sleep(5)
             print('.', end='')
+
+        if timeout is not None and timeout > (time.time() - start_time):
+            LOG.debug("Timeout of '%s' seconds was reached for fetching indicator data.", timeout)
+            break
     print()
 
     wrapper = TimeseriesDataset(results, indicator_set, equipment_set, start_date, end_date)

--- a/sailor/utils/timestamps.py
+++ b/sailor/utils/timestamps.py
@@ -45,6 +45,23 @@ def _any_to_timestamp(value, default: pd.Timestamp = None):
     return timestamp
 
 
+def _any_to_timedelta(value, default: pd.Timedelta = None):
+    """Try to parse a timedelta provided in a variety of formats into a uniform representation as pd.Timedelta."""
+    if value is None:
+        return default
+
+    if isinstance(value, str):
+        timedelta = pd.Timedelta(value)
+    elif isinstance(value, datetime.timedelta):
+        timedelta = pd.Timedelta(value)
+    elif isinstance(value, pd.Timedelta):
+        timedelta = value
+    else:
+        raise RuntimeError('Can only parse ISO 8601 strings, pandas timesdeltas or python native timedeltas.')
+
+    return timedelta
+
+
 def _timestamp_to_isoformat(timestamp: pd.Timestamp, with_zulu=False):
     """Return an iso-format string of a timestamp after conversion to UTC and without the timezone information."""
     if timestamp.tzinfo:

--- a/sailor/utils/timestamps.py
+++ b/sailor/utils/timestamps.py
@@ -27,12 +27,12 @@ def _any_to_timestamp(value, default: pd.Timestamp = None):
 
     if isinstance(value, str):
         timestamp = pd.Timestamp(value)
+    elif isinstance(value, pd.Timestamp):
+        timestamp = value
     elif isinstance(value, datetime.datetime):
         timestamp = pd.Timestamp(value)
     elif isinstance(value, datetime.date):
         timestamp = pd.Timestamp(value)
-    elif isinstance(value, pd.Timestamp):
-        timestamp = value
     else:
         raise RuntimeError('Can only parse ISO 8601 strings, pandas timestamps or python native timestamps.')
 
@@ -52,10 +52,10 @@ def _any_to_timedelta(value, default: pd.Timedelta = None):
 
     if isinstance(value, str):
         timedelta = pd.Timedelta(value)
-    elif isinstance(value, datetime.timedelta):
-        timedelta = pd.Timedelta(value)
     elif isinstance(value, pd.Timedelta):
         timedelta = value
+    elif isinstance(value, datetime.timedelta):
+        timedelta = pd.Timedelta(value)
     else:
         raise RuntimeError('Can only parse ISO 8601 strings, pandas timesdeltas or python native timedeltas.')
 

--- a/tests/test_sailor/test_sap_iot/test_fetch.py
+++ b/tests/test_sailor/test_sap_iot/test_fetch.py
@@ -284,7 +284,7 @@ class TestRawDataWrapperFunction:
         mock_gzip.side_effect = [BytesIO(make_csv_bytes(1, ''))]
         mock_check.return_value = False
 
-        with pytest.raises(RuntimeError, match='Timeout of 2 seconds was reached for fetching indicator data.'):
+        with pytest.raises(TimeoutError, match='Timeout of 2 seconds was reached for fetching indicator data.'):
             get_indicator_data('2020-01-01T00:00:00Z', '2020-02-01T00:00:00Z', indicator_set, equipment_set, timeout="P2S")
 
 

--- a/tests/test_sailor/test_sap_iot/test_fetch.py
+++ b/tests/test_sailor/test_sap_iot/test_fetch.py
@@ -265,6 +265,29 @@ class TestRawDataWrapperFunction:
         with pytest.warns(DataNotFoundWarning, match='Could not find any data for indicator.*indicator_id_3.*'):
             get_indicator_data('2020-01-01T00:00:00Z', '2020-02-01T00:00:00Z', indicator_set, equipment_set)
 
+    @pytest.mark.filterwarnings('ignore:Could not find any data for indicator')
+    @pytest.mark.filterwarnings('ignore:There is no data in the dataframe for some of the indicators')
+    @pytest.mark.filterwarnings('ignore:There is no data in the dataframe for some of the equipments')
+    @patch('sailor.sap_iot.fetch._check_bulk_timeseries_export_status')
+    def test_get_indicator_data_timeout_reached(self, mock_check, caplog, mock_zipfile, mock_gzip, mock_config,
+                                                mock_request, make_indicator_set, make_equipment_set, make_csv_bytes):
+
+        indicator_set = make_indicator_set(propertyId=['indicator_id_1'])
+        equipment_set = make_equipment_set(equipmentId=['equipment_id_1'])
+
+        mock_request.side_effect = [
+            {'RequestId': 'test_request_id_1'},
+            {'Status': 'The file is available for download.'}, b'mock_zip_content',
+        ]
+        mock_zipfile.ZipFile.return_value.filelist = ['inner_file_1']
+        mock_zipfile.ZipFile.return_value.read.return_value = b'mock_gzip_content'
+        mock_gzip.side_effect = [BytesIO(make_csv_bytes(1, ''))]
+        mock_check.return_value = False
+
+        caplog.set_level("DEBUG")
+        get_indicator_data('2020-01-01T00:00:00Z', '2020-02-01T00:00:00Z', indicator_set, equipment_set, timeout="P2S")
+        assert 'Timeout of 2 seconds was reached for fetching indicator data.' in caplog.messages
+
 
 @pytest.mark.filterwarnings('ignore:Could not find any data for indicator')
 @pytest.mark.filterwarnings('ignore:There is no data in the dataframe for some of the indicators')

--- a/tests/test_sailor/test_sap_iot/test_fetch.py
+++ b/tests/test_sailor/test_sap_iot/test_fetch.py
@@ -284,9 +284,8 @@ class TestRawDataWrapperFunction:
         mock_gzip.side_effect = [BytesIO(make_csv_bytes(1, ''))]
         mock_check.return_value = False
 
-        caplog.set_level("DEBUG")
-        get_indicator_data('2020-01-01T00:00:00Z', '2020-02-01T00:00:00Z', indicator_set, equipment_set, timeout="P2S")
-        assert 'Timeout of 2 seconds was reached for fetching indicator data.' in caplog.messages
+        with pytest.raises(RuntimeError, match='Timeout of 2 seconds was reached for fetching indicator data.'):
+            get_indicator_data('2020-01-01T00:00:00Z', '2020-02-01T00:00:00Z', indicator_set, equipment_set, timeout="P2S")
 
 
 @pytest.mark.filterwarnings('ignore:Could not find any data for indicator')

--- a/tests/test_sailor/test_sap_iot/test_fetch.py
+++ b/tests/test_sailor/test_sap_iot/test_fetch.py
@@ -285,7 +285,8 @@ class TestRawDataWrapperFunction:
         mock_check.return_value = False
 
         with pytest.raises(TimeoutError, match='Timeout of 2 seconds was reached for fetching indicator data.'):
-            get_indicator_data('2020-01-01T00:00:00Z', '2020-02-01T00:00:00Z', indicator_set, equipment_set, timeout="P2S")
+            get_indicator_data('2020-01-01T00:00:00Z', '2020-02-01T00:00:00Z', indicator_set, equipment_set,
+                               timeout="P2S")
 
 
 @pytest.mark.filterwarnings('ignore:Could not find any data for indicator')

--- a/tests/test_sailor/test_utils/test_timestamps.py
+++ b/tests/test_sailor/test_utils/test_timestamps.py
@@ -4,7 +4,8 @@ import warnings
 import pytest
 import pandas as pd
 
-from sailor.utils.timestamps import _any_to_timestamp, _calculate_nice_sub_intervals, _timestamp_to_date_string
+from sailor.utils.timestamps import _any_to_timestamp, _any_to_timedelta, _calculate_nice_sub_intervals,\
+    _timestamp_to_date_string
 
 
 @pytest.mark.parametrize('testdescription,input,expected', [
@@ -24,6 +25,25 @@ from sailor.utils.timestamps import _any_to_timestamp, _calculate_nice_sub_inter
 @pytest.mark.filterwarnings('ignore:Trying to parse non-timezone-aware timestamp, assuming UTC.')
 def test_any_to_timestamp_types(input, expected, testdescription):
     actual = _any_to_timestamp(input)
+    assert actual == expected
+
+
+@pytest.mark.parametrize('testdescription,input,expected', [
+    ('iso8601 string',
+        'P2DT1H50M30S',
+        pd.Timedelta(days=2, hours=1, minutes=50, seconds=30)),
+    ('"<D> days <hours>:<min>:<seconds>" string ',
+        '2 days 01:50:30',
+        pd.Timedelta(days=2, hours=1, minutes=50, seconds=30)),
+    ('datetime.timedelta',
+        datetime.timedelta(days=2, hours=1, minutes=50, seconds=30),
+        pd.Timedelta(days=2, hours=1, minutes=50, seconds=30)),
+    ('pd.Timedelta',
+        pd.Timedelta(days=2, hours=1, minutes=50, seconds=30),
+        pd.Timedelta(days=2, hours=1, minutes=50, seconds=30))
+])
+def test_any_to_timedelta_types(input, expected, testdescription):
+    actual = _any_to_timedelta(input)
     assert actual == expected
 
 


### PR DESCRIPTION
# Description

When getting indicator data, we need to wait until the data is ready for download. In interactive mode a user can (manually) abort, if the request takes too long. But especially if the code is run in the background non-interactively, it makes sense to provide a parameter, which specifies the maximum amount of waiting time. Therefore the `timeout` parameter is added. If no value is specified, no time limit is set.

# Checklist

Mark "not applicable" if item on the list does not apply to this pull request.

- [x] I have created/adapted unit tests for new code
  - [ ] not applicable 
- [ ] I have added new dependencies as described at the [Contributing](https://sap.github.io/project-sailor/contributing.html#requirements-management) page
  - [x] not applicable 
- [x] I have made corresponding changes to the documentation (incl. tutorial, etc.)
  - [ ] not applicable 
- [ ] I have provided release notes (in description or as comment) if this PR is a new feature OR a change worth mentioning for next release
  - [x] not applicable 
- [ ] I have obtained API approvals if a new SAP API or endpoint is used
  - [x] not applicable 
