### PR TITLE
Handle FutureWarning for pytest | log our upload warning

### DIFF
--- a/sailor/sap_iot/write.py
+++ b/sailor/sap_iot/write.py
@@ -9,11 +9,11 @@ indicator and equipment information is taken from the TimeseriesDataset.
 from functools import partial
 from collections import defaultdict
 import logging
-import warnings
 
 import numpy as np
 
 import sailor.assetcentral.indicators as ac_indicators
+from sailor.utils.utils import WarningAdapter
 from ..assetcentral.utils import _ac_application_url
 from ..assetcentral.constants import VIEW_TEMPLATES
 from ..utils.timestamps import _timestamp_to_isoformat
@@ -23,6 +23,7 @@ from ._common import request_upload_url
 
 LOG = logging.getLogger(__name__)
 LOG.addHandler(logging.NullHandler())
+LOG = WarningAdapter(LOG)
 
 
 # Unfortunately there is no guidance from SAP IoT yet on how much data can be uploaded at once.
@@ -133,9 +134,9 @@ def upload_indicator_data(dataset: TimeseriesDataset, force_update=True):
         upload_indicator_data(my_timeseries_data)
     """
     if force_update is True:
-        warnings.warn('Starting June 1st this function will raise an error if not all indicators' +
-                      ' in the IndicatorSet are provided in the data. To recover the current behaviour' +
-                      ' you will have to specify force_update=True', category=FutureWarning)
+        LOG.log_with_warning('Starting July 1st this function will raise an error if not all indicators' +
+                             ' in the IndicatorSet are provided in the data. To recover the current behaviour' +
+                             ' you will have to specify force_update=True', warning_category=FutureWarning)
 
     if isinstance(dataset.indicator_set, ac_indicators.AggregatedIndicatorSet):
         raise RuntimeError('TimeseriesDatasets containing aggregated indicators may not be uploaded to SAP IoT')

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ add-ignore = D104,D404
 # unexpected warnings must be fixed. if not possible immediately, add to the list below.
 filterwarnings = default
     error::Warning
+    once:Argument `closed` is deprecated:FutureWarning:sailor.sap_iot.wrappers
     once::DeprecationWarning
 
 

--- a/tests/test_sailor/test_sap_iot/test_write.py
+++ b/tests/test_sailor/test_sap_iot/test_write.py
@@ -14,7 +14,7 @@ def mock_upload_url():
         yield mock
 
 
-@pytest.mark.filterwarnings('ignore:Starting June 1st this function will raise an error if not all indicators')
+@pytest.mark.filterwarnings('ignore:Starting July 1st this function will raise an error if not all indicators')
 def test_upload_is_split_by_indicator_group_and_template(mock_request, make_indicator_set, make_equipment_set):
     indicator_set = make_indicator_set(
         propertyId=['indicator_id_A', 'indicator_id_B', 'indicator_id_A'],
@@ -45,7 +45,7 @@ def test_upload_is_split_by_indicator_group_and_template(mock_request, make_indi
         assert all(value.keys() == {'_time', indicator._liot_id} for value in matching_payload['Values'])
 
 
-@pytest.mark.filterwarnings('ignore:Starting June 1st this function will raise an error if not all indicators')
+@pytest.mark.filterwarnings('ignore:Starting July 1st this function will raise an error if not all indicators')
 def test_upload_one_group_in_one_request(mock_request, make_indicator_set, make_equipment_set):
     indicator_set = make_indicator_set(
         propertyId=['indicator_id_A', 'indicator_id_B', 'indicator_id_A'],
@@ -78,7 +78,7 @@ def test_upload_one_group_in_one_request(mock_request, make_indicator_set, make_
         assert all(value.keys() == expected_keys for value in matching_payload['Values'])
 
 
-@pytest.mark.filterwarnings('ignore:Starting June 1st this function will raise an error if not all indicators')
+@pytest.mark.filterwarnings('ignore:Starting July 1st this function will raise an error if not all indicators')
 def test_each_equipment_one_request(mock_request, mock_upload_url, make_indicator_set, make_equipment_set):
     indicator_set = make_indicator_set(propertyId=['indicator_id_A', 'indicator_id_B'])
     equipment_set = make_equipment_set(equipmentId=['equipment_A', 'equipment_B'])
@@ -93,7 +93,7 @@ def test_each_equipment_one_request(mock_request, mock_upload_url, make_indicato
     assert urls == {request_base + equipment.id for equipment in equipment_set}
 
 
-@pytest.mark.filterwarnings('ignore:Starting June 1st this function will raise an error if not all indicators')
+@pytest.mark.filterwarnings('ignore:Starting July 1st this function will raise an error if not all indicators')
 def test_nan_dataset_written(mock_request, make_indicator_set, make_equipment_set):
     indicator_set = make_indicator_set(propertyId=['indicator_id_A', 'indicator_id_B'])
     equipment_set = make_equipment_set(equipmentId=['equipment_A'])


### PR DESCRIPTION
# Description

This PR handles two things:

pandas FutureWarning:
- from pandas 1.4.x onwards, a feature we use has been deprecated
- ignore this warning for the time being to give Sailor users time to upgrade

upload_indicator_data update warning:
- Our own warning should be logged, too.
- Extend the warning duration to July to give users ample time starting from our next release

# Additional information

You can install the latest pandas version and execute pytest with the main branch to see that it fails because of the FutureWarning of pandas.
Then execute pytest with this branch to see that the FutureWarning only shows up as a warning again.

# Checklist

Mark "not applicable" if item on the list does not apply to this pull request.

- [ ] I have created/adapted unit tests for new code
  - [ ] not applicable 
- [ ] I have added new dependencies as described at the [Contributing](https://sap.github.io/project-sailor/contributing.html#requirements-management) page
  - [ ] not applicable 
- [ ] I have made corresponding changes to the documentation (incl. tutorial, etc.)
  - [ ] not applicable 
- [ ] I have provided release notes (in description or as comment) if this PR is a new feature OR a change worth mentioning for next release
  - [ ] not applicable 
- [ ] I have obtained API approvals if a new SAP API or endpoint is used
  - [ ] not applicable 
