### PR TITLE
Pagination of results for Assetcentral/PAI APIs

### DIFF
--- a/sailor/_base/fetch.py
+++ b/sailor/_base/fetch.py
@@ -4,14 +4,14 @@ from typing import List
 import re
 import logging
 
-from sailor.utils.oauth_wrapper import get_oauth_client
+from sailor.utils.oauth_wrapper import get_oauth_client, RequestError
 from sailor.utils.utils import DataNotFoundWarning, _is_non_string_iterable, WarningAdapter
 
 LOG = logging.getLogger(__name__)
 LOG.addHandler(logging.NullHandler())
 LOG = WarningAdapter(LOG)
 
-
+_FETCH_CALL_RETRY_LIMIT = 10
 _OPERATOR_MAP = {
     '>': 'gt',
     '<': 'lt',
@@ -20,15 +20,18 @@ _OPERATOR_MAP = {
     '!=': 'ne',
     '==': 'eq'
 }
-
 _EXTENDED_FILTER_PATTERN = re.compile(r'^(\w+) *?(>=|<=|==|!=|<|>) *(.*?)$')
 
 
-def fetch_data(client_name, response_handler, endpoint_url, unbreakable_filters=(), breakable_filters=()) -> List:
+def fetch_data(client_name, response_handler, error_handler, endpoint_url, unbreakable_filters=(), breakable_filters=(),
+               *, paginate=False) -> List:
     """Retrieve data from a supported odata service.
 
-    A response_handler function needs to be passed which must extract the results
-    returned from the odata service endpoint response into a list.
+    response handler
+        A function that accepts (result_filter, endpoint_data) and needs to modify the ``result_filter`` list.
+    error_handler
+        A function that accepts (RequestError, retry_count) and decides based on this input whether to retry the last
+        request or re-raise the error. Should not return anything if a retry should be attempted.
     """
     filters = _compose_queries(unbreakable_filters, breakable_filters)
     oauth_client = get_oauth_client(client_name)
@@ -39,19 +42,50 @@ def fetch_data(client_name, response_handler, endpoint_url, unbreakable_filters=
     result = []
     for filter_string in filters:
         result_filter = []
-
         params = {'$filter': filter_string} if filter_string else {}
-        params.update({'$format': 'json'})
-
-        endpoint_data = oauth_client.request('GET', endpoint_url, params=params)
-        result_filter = response_handler(result_filter, endpoint_data)
-
+        if paginate:
+            result_filter = _fetch_call_paginate(oauth_client, response_handler, error_handler, endpoint_url, params,
+                                                 result_filter)
+        else:
+            result_filter = _fetch_call(oauth_client, response_handler, error_handler, endpoint_url, params,
+                                        result_filter)
         result.extend(result_filter)
 
     if len(result) == 0:
         LOG.log_with_warning(DataNotFoundWarning(), warning_stacklevel=2)
 
     return result
+
+
+def _fetch_call(oauth_client, response_handler, error_handler, endpoint_url, params, result_filter):
+    params.update({'$format': 'json'})
+    endpoint_data = None
+    retry_count = 0
+    while endpoint_data is None:
+        try:
+            endpoint_data = oauth_client.request('GET', endpoint_url, params=params)
+        except RequestError as exc:
+            # safeguard against error_handlers that are not implemented correctly
+            if (retry_count := retry_count + 1) > _FETCH_CALL_RETRY_LIMIT:
+                raise
+            error_handler(exc, retry_count)
+
+    result_filter = response_handler(result_filter, endpoint_data)
+    return result_filter
+
+
+def _fetch_call_paginate(oauth_client, response_handler, error_handler, endpoint_url, params, result_filter):
+    skip = 0
+    while True:
+        params.update({'$skip': skip, '$top': 50000})
+
+        result_filter = _fetch_call(oauth_client, response_handler, error_handler, endpoint_url, params, result_filter)
+
+        if skip >= len(result_filter):
+            break
+        skip = len(result_filter)
+        LOG.info('Fetch data progress: %d', skip)
+    return result_filter
 
 
 def parse_filter_parameters(equality_filters=None, extended_filters=(), field_map=None):

--- a/sailor/assetcentral/equipment.py
+++ b/sailor/assetcentral/equipment.py
@@ -503,6 +503,6 @@ def find_equipment(*, extended_filters=(), **kwargs) -> EquipmentSet:
         _base.parse_filter_parameters(kwargs, extended_filters, Equipment._field_map)
 
     endpoint_url = _ac_application_url() + VIEW_EQUIPMENT
-    object_list = _ac_fetch_data(endpoint_url, unbreakable_filters, breakable_filters)
+    object_list = _ac_fetch_data(endpoint_url, unbreakable_filters, breakable_filters, paginate=True)
     LOG.debug('Found %d equipments for the specified filters.', len(object_list))
     return EquipmentSet([Equipment(obj) for obj in object_list])

--- a/sailor/assetcentral/failure_mode.py
+++ b/sailor/assetcentral/failure_mode.py
@@ -135,6 +135,6 @@ def find_failure_modes(*, extended_filters=(), **kwargs) -> FailureModeSet:
         _base.parse_filter_parameters(kwargs, extended_filters, FailureMode._field_map)
 
     endpoint_url = _ac_application_url() + VIEW_FAILUREMODES
-    object_list = _ac_fetch_data(endpoint_url, unbreakable_filters, breakable_filters)
+    object_list = _ac_fetch_data(endpoint_url, unbreakable_filters, breakable_filters, paginate=True)
     LOG.debug('Found %d failure modes for the specified filters.', len(object_list))
     return FailureModeSet([FailureMode(obj) for obj in object_list])

--- a/sailor/assetcentral/functional_location.py
+++ b/sailor/assetcentral/functional_location.py
@@ -120,6 +120,6 @@ def find_functional_locations(*, extended_filters=(), **kwargs) -> FunctionalLoc
         _base.parse_filter_parameters(kwargs, extended_filters, FunctionalLocation._field_map)
 
     endpoint_url = _ac_application_url() + VIEW_FUNCTIONAL_LOCATIONS
-    object_list = _ac_fetch_data(endpoint_url, unbreakable_filters, breakable_filters)
+    object_list = _ac_fetch_data(endpoint_url, unbreakable_filters, breakable_filters, paginate=True)
     LOG.debug('Found %d functional locations for the specified filters.', len(object_list))
     return FunctionalLocationSet([FunctionalLocation(obj) for obj in object_list])

--- a/sailor/assetcentral/location.py
+++ b/sailor/assetcentral/location.py
@@ -109,6 +109,6 @@ def find_locations(*, extended_filters=(), **kwargs) -> LocationSet:
 
     endpoint_url = _ac_application_url() + VIEW_LOCATIONS
 
-    object_list = _ac_fetch_data(endpoint_url, unbreakable_filters, breakable_filters)
+    object_list = _ac_fetch_data(endpoint_url, unbreakable_filters, breakable_filters, paginate=True)
     LOG.debug('Found %d locations for the specified filters.', len(object_list))
     return LocationSet([Location(obj) for obj in object_list])

--- a/sailor/assetcentral/model.py
+++ b/sailor/assetcentral/model.py
@@ -188,6 +188,6 @@ def find_models(*, extended_filters=(), **kwargs) -> ModelSet:
         _base.parse_filter_parameters(kwargs, extended_filters, Model._field_map)
 
     endpoint_url = _ac_application_url() + VIEW_MODELS
-    object_list = _ac_fetch_data(endpoint_url, unbreakable_filters, breakable_filters)
+    object_list = _ac_fetch_data(endpoint_url, unbreakable_filters, breakable_filters, paginate=True)
     LOG.debug('Found %d models for the specified filters.', len(object_list))
     return ModelSet([Model(obj) for obj in object_list])

--- a/sailor/assetcentral/notification.py
+++ b/sailor/assetcentral/notification.py
@@ -270,7 +270,7 @@ def find_notifications(*, extended_filters=(), **kwargs) -> NotificationSet:
         _base.parse_filter_parameters(kwargs, extended_filters, Notification._field_map)
 
     endpoint_url = _ac_application_url() + VIEW_NOTIFICATIONS
-    object_list = _ac_fetch_data(endpoint_url, unbreakable_filters, breakable_filters)
+    object_list = _ac_fetch_data(endpoint_url, unbreakable_filters, breakable_filters, paginate=True)
     LOG.debug('Found %d notifications for the specified filters.', len(object_list))
     return NotificationSet([Notification(obj) for obj in object_list])
 

--- a/sailor/assetcentral/system.py
+++ b/sailor/assetcentral/system.py
@@ -440,7 +440,7 @@ def find_systems(*, extended_filters=(), **kwargs) -> SystemSet:
         _base.parse_filter_parameters(kwargs, extended_filters, System._field_map)
 
     endpoint_url = _ac_application_url() + VIEW_SYSTEMS
-    object_list = _ac_fetch_data(endpoint_url, unbreakable_filters, breakable_filters)
+    object_list = _ac_fetch_data(endpoint_url, unbreakable_filters, breakable_filters, paginate=True)
     LOG.debug('Found %d systems for the specified filters.', len(object_list))
 
     return SystemSet([System(obj) for obj in object_list])

--- a/sailor/assetcentral/workorder.py
+++ b/sailor/assetcentral/workorder.py
@@ -136,6 +136,6 @@ def find_workorders(*, extended_filters=(), **kwargs) -> WorkorderSet:
         _base.parse_filter_parameters(kwargs, extended_filters, Workorder._field_map)
 
     endpoint_url = _ac_application_url() + VIEW_WORKORDERS
-    object_list = _ac_fetch_data(endpoint_url, unbreakable_filters, breakable_filters)
+    object_list = _ac_fetch_data(endpoint_url, unbreakable_filters, breakable_filters, paginate=True)
     LOG.debug('Found %d workorders for the specified filters.', len(object_list))
     return WorkorderSet([Workorder(obj) for obj in object_list])

--- a/sailor/pai/alert.py
+++ b/sailor/pai/alert.py
@@ -207,7 +207,7 @@ def find_alerts(*, extended_filters=(), **kwargs) -> AlertSet:
         _base.parse_filter_parameters(kwargs, extended_filters, Alert._field_map)
 
     endpoint_url = _pai_application_url() + ALERTS_READ_PATH
-    object_list = _pai_fetch_data(endpoint_url, unbreakable_filters, breakable_filters)
+    object_list = _pai_fetch_data(endpoint_url, unbreakable_filters, breakable_filters, paginate=True)
 
     LOG.debug('Found %d alerts for the specified filters.', len(object_list))
     return AlertSet([Alert(obj) for obj in object_list])

--- a/sailor/pai/utils.py
+++ b/sailor/pai/utils.py
@@ -2,17 +2,22 @@
 
 
 from sailor import _base
+from sailor.utils.oauth_wrapper.OAuthServiceImpl import RequestError
 from ..utils.config import SailorConfig
 
 
-def _pai_fetch_data(endpoint_url, unbreakable_filters=(), breakable_filters=()):
-    return _base.fetch_data('predictive_asset_insights', _pai_response_handler,
-                            endpoint_url, unbreakable_filters, breakable_filters)
+def _pai_fetch_data(endpoint_url, unbreakable_filters=(), breakable_filters=(), **kwargs):
+    return _base.fetch_data('predictive_asset_insights', _pai_response_handler, _pai_error_handler,
+                            endpoint_url, unbreakable_filters, breakable_filters, **kwargs)
 
 
 def _pai_application_url():
     """Return the PredictiveAssetInsights (PAI) application URL from the SailorConfig."""
     return SailorConfig.get('predictive_asset_insights', 'application_url')
+
+
+def _pai_error_handler(exc: RequestError, retry_count):
+    raise exc
 
 
 def _pai_response_handler(result_list, endpoint_data):

--- a/tests/test_sailor/test_assetcentral/test_utils.py
+++ b/tests/test_sailor/test_assetcentral/test_utils.py
@@ -110,7 +110,7 @@ def test_ac_fetch_data_integration(mock_request):
                            '$format': 'json'}
     expected = mock_request.return_value = ['result1']
 
-    actual = _ac_fetch_data('', unbreakable_filters, breakable_filters)
+    actual = _ac_fetch_data('', unbreakable_filters, breakable_filters, paginate=False)
 
     mock_request.assert_called_once_with('GET', '', params=expected_parameters)
     assert actual == expected
@@ -121,7 +121,7 @@ def test_ac_fetch_data_rate_limiting(mock_sleep, mock_request):
     exception = RequestError('test_message', 429, 'reason', 'error_text')
     mock_request.side_effect = [exception, 'retry-response']
 
-    actual = _ac_fetch_data('')
+    actual = _ac_fetch_data('', paginate=False)
 
     assert mock_request.call_count == 2
     assert actual == ['retry-response']

--- a/tests/test_sailor/test_pai/test_utils.py
+++ b/tests/test_sailor/test_pai/test_utils.py
@@ -17,7 +17,7 @@ def test_pai_fetch_data_integration(mock_request):
     expected = ['result1', 'result2']
     mock_request.return_value = {'d': {'results': expected}}
 
-    actual = _pai_fetch_data('', unbreakable_filters, breakable_filters)
+    actual = _pai_fetch_data('', unbreakable_filters, breakable_filters, paginate=False)
 
     mock_request.assert_called_once_with('GET', '', params=expected_parameters)
     assert actual == expected


### PR DESCRIPTION
# Description

Assetcentral/PAI API limits the result set by default which may result in truncated result sets when using Sailor's find_* functions.
The only way to work around this for the end-user is to manually split the expected result into multiple find_* function calls based on some carefully chosen attribute(s) and values.

Each API supports pagination for most entities.
This commit implements pagination and makes use of it for all supported entities. That means that a single find_* function call will now return the entire result set by using fetch pagination in the background.

The focus of this implementation is on completeness and correctness. There are no performance gains to be expected. The feature is implemented using synchronous calls.

Fixes #40 

# Release notes
- **Enhancement:** Pagination of results for Assetcentral/PAI APIs. 
    find_* functions now go beyond the result set limits imposed by those APIs.

# Checklist

Mark "not applicable" if item on the list does not apply to this pull request.

- [x] I have created/adapted unit tests for new code
  - [ ] not applicable 
- [ ] I have added new dependencies as described at the [Contributing](https://sap.github.io/project-sailor/contributing.html#requirements-management) page
  - [x] not applicable 
- [ ] I have made corresponding changes to the documentation (incl. tutorial, etc.)
  - [x] not applicable 
- [x] I have provided release notes (in description or as comment) if this PR is a new feature OR a change worth mentioning for next release
  - [ ] not applicable 
- [ ] I have obtained API approvals if a new SAP API or endpoint is used
  - [x] not applicable 
