### PR TITLE
Make indicator group completeness check default

### DIFF
--- a/sailor/sap_iot/write.py
+++ b/sailor/sap_iot/write.py
@@ -103,7 +103,7 @@ def _check_indicator_group_is_complete(uploaded_indicators, indicator_group_id, 
                            'If this is wanted, use "force_update" in the function call.')
 
 
-def upload_indicator_data(dataset: TimeseriesDataset, force_update=True):
+def upload_indicator_data(dataset: TimeseriesDataset, force_update=False):
     """
     Upload a `TimeseriesDataset` to SAP IoT.
 
@@ -133,11 +133,6 @@ def upload_indicator_data(dataset: TimeseriesDataset, force_update=True):
 
         upload_indicator_data(my_timeseries_data)
     """
-    if force_update is True:
-        LOG.log_with_warning('Starting July 1st this function will raise an error if not all indicators' +
-                             ' in the IndicatorSet are provided in the data. To recover the current behaviour' +
-                             ' you will have to specify force_update=True', warning_category=FutureWarning)
-
     if isinstance(dataset.indicator_set, ac_indicators.AggregatedIndicatorSet):
         raise RuntimeError('TimeseriesDatasets containing aggregated indicators may not be uploaded to SAP IoT')
 

--- a/tests/test_sailor/test_sap_iot/test_write.py
+++ b/tests/test_sailor/test_sap_iot/test_write.py
@@ -14,7 +14,6 @@ def mock_upload_url():
         yield mock
 
 
-@pytest.mark.filterwarnings('ignore:Starting July 1st this function will raise an error if not all indicators')
 def test_upload_is_split_by_indicator_group_and_template(mock_request, make_indicator_set, make_equipment_set):
     indicator_set = make_indicator_set(
         propertyId=['indicator_id_A', 'indicator_id_B', 'indicator_id_A'],
@@ -45,7 +44,6 @@ def test_upload_is_split_by_indicator_group_and_template(mock_request, make_indi
         assert all(value.keys() == {'_time', indicator._liot_id} for value in matching_payload['Values'])
 
 
-@pytest.mark.filterwarnings('ignore:Starting July 1st this function will raise an error if not all indicators')
 def test_upload_one_group_in_one_request(mock_request, make_indicator_set, make_equipment_set):
     indicator_set = make_indicator_set(
         propertyId=['indicator_id_A', 'indicator_id_B', 'indicator_id_A'],
@@ -78,7 +76,6 @@ def test_upload_one_group_in_one_request(mock_request, make_indicator_set, make_
         assert all(value.keys() == expected_keys for value in matching_payload['Values'])
 
 
-@pytest.mark.filterwarnings('ignore:Starting July 1st this function will raise an error if not all indicators')
 def test_each_equipment_one_request(mock_request, mock_upload_url, make_indicator_set, make_equipment_set):
     indicator_set = make_indicator_set(propertyId=['indicator_id_A', 'indicator_id_B'])
     equipment_set = make_equipment_set(equipmentId=['equipment_A', 'equipment_B'])
@@ -93,7 +90,6 @@ def test_each_equipment_one_request(mock_request, mock_upload_url, make_indicato
     assert urls == {request_base + equipment.id for equipment in equipment_set}
 
 
-@pytest.mark.filterwarnings('ignore:Starting July 1st this function will raise an error if not all indicators')
 def test_nan_dataset_written(mock_request, make_indicator_set, make_equipment_set):
     indicator_set = make_indicator_set(propertyId=['indicator_id_A', 'indicator_id_B'])
     equipment_set = make_equipment_set(equipmentId=['equipment_A'])

--- a/tests/test_sailor/test_sap_iot/test_write.py
+++ b/tests/test_sailor/test_sap_iot/test_write.py
@@ -134,7 +134,7 @@ def test_check_indicator_group_is_complete(mock_request):
     response = _check_indicator_group_is_complete(uploaded_indicators, indicator_group_id, 'template')
 
     assert mock_request.call_count == 1
-    assert(response is None)
+    assert response is None
 
 
 def test_check_indicator_group_is_complete_raise_error(mock_request):


### PR DESCRIPTION
# Description

Check whether the indicator group is complete to prevent overwriting unspecified indicators with NaN values.

This check is now the default behaviour. To restore the old behaviour, set force_update=True.

# Checklist

Mark "not applicable" if item on the list does not apply to this pull request.

- [ ] I have created/adapted unit tests for new code
  - [x] not applicable 
- [ ] I have added new dependencies as described at the [Contributing](https://sap.github.io/project-sailor/contributing.html#requirements-management) page
  - [x] not applicable 
- [ ] I have made corresponding changes to the documentation (incl. tutorial, etc.)
  - [x] not applicable 
- [ ] I have provided release notes (in description or as comment) if this PR is a new feature OR a change worth mentioning for next release
  - [x] not applicable 
- [ ] I have obtained API approvals if a new SAP API or endpoint is used
  - [x] not applicable 
