### PR TITLE
Fix API incompatibility after PAI update (create alert)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,17 +4,15 @@
 #
 #    pip-compile requirements.in
 #
-cachetools==5.0.0
+cachetools==5.2.0
     # via -r requirements.in
-certifi==2021.10.8
+certifi==2022.6.15
     # via requests
-charset-normalizer==2.0.12
+charset-normalizer==2.1.0
     # via requests
 cycler==0.11.0
     # via matplotlib
-descartes==1.1.0
-    # via plotnine
-fonttools==4.32.0
+fonttools==4.34.4
     # via matplotlib
 furl==2.1.3
     # via -r requirements.in
@@ -24,17 +22,16 @@ isodate==0.6.1
     # via -r requirements.in
 joblib==1.1.0
     # via scikit-learn
-kiwisolver==1.4.2
+kiwisolver==1.4.4
     # via matplotlib
-matplotlib==3.5.1
+matplotlib==3.5.2
     # via
     #   -r requirements.in
-    #   descartes
     #   mizani
     #   plotnine
 mizani==0.7.4
     # via plotnine
-numpy==1.22.3
+numpy==1.23.1
     # via
     #   matplotlib
     #   mizani
@@ -52,7 +49,7 @@ packaging==21.3
     #   statsmodels
 palettable==3.3.0
     # via mizani
-pandas==1.4.2
+pandas==1.4.3
     # via
     #   -r requirements.in
     #   mizani
@@ -62,13 +59,13 @@ patsy==0.5.2
     # via
     #   plotnine
     #   statsmodels
-pillow==9.1.1
+pillow==9.2.0
     # via matplotlib
-plotnine==0.8.0
+plotnine==0.9.0
     # via -r requirements.in
 pyjwt==2.4.0
     # via -r requirements.in
-pyparsing==3.0.8
+pyparsing==3.0.9
     # via
     #   matplotlib
     #   packaging
@@ -82,13 +79,13 @@ pyyaml==6.0
     # via -r requirements.in
 rauth==0.7.3
     # via -r requirements.in
-requests==2.27.1
+requests==2.28.1
     # via
     #   -r requirements.in
     #   rauth
-scikit-learn==1.0.2
+scikit-learn==1.1.2
     # via -r requirements.in
-scipy==1.8.0
+scipy==1.9.0
     # via
     #   mizani
     #   plotnine
@@ -105,5 +102,5 @@ statsmodels==0.13.2
     # via plotnine
 threadpoolctl==3.1.0
     # via scikit-learn
-urllib3==1.26.9
+urllib3==1.26.11
     # via requests

--- a/sailor/pai/alert.py
+++ b/sailor/pai/alert.py
@@ -250,7 +250,7 @@ def _create_alert(request) -> Alert:
     endpoint_url = ac_utils._ac_application_url() + ALERTS_WRITE_PATH
     oauth_client = get_oauth_client('asset_central')
 
-    response = oauth_client.request('POST', endpoint_url, json=request.data)
+    response = oauth_client.request('POST', endpoint_url, json=request.data, headers={'Accept': 'text/plain'})
     response = response.decode('utf-8')
     LOG.debug('Response of alert creation: \n%s', response)
     alert_id = re.search(r'[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}',

--- a/sailor/utils/oauth_wrapper/OAuthServiceImpl.py
+++ b/sailor/utils/oauth_wrapper/OAuthServiceImpl.py
@@ -94,11 +94,7 @@ class OAuth2Client():
         response = session.request(method, url, **req_kwargs)
         if response.ok:
             if response.headers.get('content-type', '').lower() == 'application/json':
-                # TODO: remove this workaround when API has been fixed
-                try:
-                    return response.json()
-                except json.JSONDecodeError:
-                    return response.content
+                return response.json()
             else:
                 return response.content
         else:

--- a/tests/test_sailor/test_pai/test_alert.py
+++ b/tests/test_sailor/test_pai/test_alert.py
@@ -177,7 +177,8 @@ def test_create_alert_create_calls_and_result(mock_ac_url, mock_pai_url, mock_re
         actual = create_alert(**input_kwargs)
 
     mock_request.assert_has_calls([
-        call('POST', 'ac_base_url' + constants.ALERTS_WRITE_PATH, json=expected_request_dict),
+        call('POST', 'ac_base_url' + constants.ALERTS_WRITE_PATH, json=expected_request_dict,
+             headers={'Accept': 'text/plain'}),
         call('GET', 'pai_base_url' + constants.ALERTS_READ_PATH,
              params={'$filter': "AlertId eq '12345678-1234-1234-1234-1234567890ab'", '$format': 'json'})])
     assert type(actual) == Alert
@@ -239,7 +240,8 @@ def test_create_alert_integration(mock_pai_url, mock_ac_url, mock_request, mock_
     actual = create_alert(**create_kwargs)
 
     mock_request.assert_has_calls([
-        call('POST', 'ac_base_url/ain/services/api/v1/alerts', json=expected_request_dict),
+        call('POST', 'ac_base_url/ain/services/api/v1/alerts', json=expected_request_dict,
+             headers={'Accept': 'text/plain'}),
         call('GET', 'pai_base_url/alerts/odata/v1/Alerts', params={
             '$filter': "AlertId eq '12345678-1234-1234-1234-1234567890ab'", '$format': 'json'})])
     assert type(actual) == Alert


### PR DESCRIPTION
# Description

Assetcentral alert endpoint only accepts "text/plain" (or empty) in http "Accept" header.

# Checklist

Mark "not applicable" if item on the list does not apply to this pull request.

- [x] I have created/adapted unit tests for new code
  - [ ] not applicable 
- [ ] I have added new dependencies as described at the [Contributing](https://sap.github.io/project-sailor/contributing.html#requirements-management) page
  - [x] not applicable 
- [ ] I have made corresponding changes to the documentation (incl. tutorial, etc.)
  - [x] not applicable 
- [ ] I have provided release notes (in description or as comment) if this PR is a new feature OR a change worth mentioning for next release
  - [x] not applicable 
- [ ] I have obtained API approvals if a new SAP API or endpoint is used
  - [x] not applicable 
