### PR TITLE
Limit supported pandas version to less than 2

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,7 @@
 furl>=2.1.3
 pyjwt>=2.4.0
 matplotlib
-pandas>=1.4.0
+pandas>=1.4.0,<2
 plotnine
 pyyaml
 rauth


### PR DESCRIPTION
Due to breaking changes in pandas 2.

# Additional information

A release still needs to be built, so that this change gets reflected in the PyPI release.

# Checklist

Mark "not applicable" if item on the list does not apply to this pull request.

- [ ] I have created/adapted unit tests for new code
  - [x] not applicable 
- [ ] I have added new dependencies as described at the [Contributing](https://sap.github.io/project-sailor/contributing.html#requirements-management) page
  - [x] not applicable 
- [ ] I have made corresponding changes to the documentation (incl. tutorial, etc.)
  - [x] not applicable 
- [ ] I have provided release notes (in description or as comment) if this PR is a new feature OR a change worth mentioning for next release
  - [x] not applicable 
- [ ] I have obtained API approvals if a new SAP API or endpoint is used
  - [x] not applicable 
