### PR TITLE
Fix: Pytest 8 captures all warnings

### DIFF
--- a/tests/test_sailor/test_sap_iot/test_fetch.py
+++ b/tests/test_sailor/test_sap_iot/test_fetch.py
@@ -222,6 +222,8 @@ class TestRawDataWrapperFunction:
 
         get_indicator_data('2020-01-01T00:00:00Z', '2020-02-01T00:00:00Z', indicator_set, equipment_set)
 
+    @pytest.mark.filterwarnings('ignore:There is no data in the dataframe for some of the indicators '
+                                'in the indicator set.')
     def test_get_indicator_data_requesterror_handled(self, mock_request, make_indicator_set):
         mock_request.side_effect = RequestError('msg', '400', 'reason',
                                                 '{"message": "Data not found for the requested date range"}')
@@ -246,6 +248,8 @@ class TestRawDataWrapperFunction:
 
         assert str(exception_info.value) == content
 
+    @pytest.mark.filterwarnings('ignore:There is no data in the dataframe for some of the indicators '
+                                'in the indicator set.')
     def test_get_indicator_data_missing_indicator_warning(self, mock_zipfile, mock_gzip, mock_config, mock_request,
                                                           make_indicator_set, make_equipment_set, make_csv_bytes):
 

--- a/tests/test_sailor/test_sap_iot/test_fetch.py
+++ b/tests/test_sailor/test_sap_iot/test_fetch.py
@@ -4,7 +4,7 @@ from unittest.mock import patch, call
 import pytest
 import pandas as pd
 
-from sailor.sap_iot.fetch import _start_bulk_timeseries_data_export, _check_bulk_timeseries_export_status,\
+from sailor.sap_iot.fetch import _start_bulk_timeseries_data_export, _check_bulk_timeseries_export_status, \
     _get_exported_bulk_timeseries_data, _process_one_file, get_indicator_data
 from sailor.sap_iot import TimeseriesDataset
 from sailor.assetcentral.indicators import IndicatorSet

--- a/tests/test_sailor/test_sap_iot/test_fetch_aggregates.py
+++ b/tests/test_sailor/test_sap_iot/test_fetch_aggregates.py
@@ -156,6 +156,8 @@ def test_get_indicator_aggregates_two_groups(mock_config, make_indicator_set, pr
 
 
 @pytest.mark.filterwarnings('ignore:Model information will be removed from the dataset after December 1 2021')
+@pytest.mark.filterwarnings('ignore:There is no data in the dataframe for some of the equipments in the equipment set.')
+@pytest.mark.filterwarnings('ignore:There is no data in the dataframe for some of the indicators in the indicator set.')
 def test_get_indicator_aggregates_empty_response(mock_config, mock_request, prepare_setup):
     start, end, equipment_set, indicator_set, aggregated_indicator_set = prepare_setup()
     timestamps = []


### PR DESCRIPTION
Pytest 8 correctly captures all warnings if multiple warnings are thrown during a
`with pytest.warns` block. Previously only the warning that the user expects was captured and tested for.

In this case, we can exclude the additional warnings, since our test is also implicitly expecting them.